### PR TITLE
Fix URL in git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ __Table of contents:__
 ## 1. Getting started
 ### 1.1 Cloning the project and its submodules
 To get started, first clone the github repository via:  
-`git clone --recurse-submodules git@github.com:ai4er-cdt/ai4er-cookiecutter.git`  
+```git clone --recurse-submodules git@github.com:ai4er-cdt/gtc-biodiversity.git```
 
 Note that this line uses the `--recurse-submodules` flag when it clones. This is needed
 if you would like to also pull the overleaf report that is linked to our project repository as 


### PR DESCRIPTION
Fixed the URL in the clone command to the gtc-biodiversity one.

Related question: is necessary to use ssh for this clone command (via `git:github.com`) or could we also just let it be via https without verification, as in `git clone --recurse-submodules https://github.com/ai4er-cdt/gtc-biodiversity.git`. The latter may have less error potential.