### PR TITLE
Feature/graph analysis loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,12 @@ target/
 
 # exclude data from source control by default
 io/
+data
+data/
+logs
+logs
+wandb
+wandb/
 
 # Mac OS-specific storage files
 .DS_Store

--- a/src/data_loading/rasterio_utils.py
+++ b/src/data_loading/rasterio_utils.py
@@ -122,12 +122,20 @@ def polygonise(
     crs: Optional[str] = None,
 ):
     """
-    Polygonise 2D numpy array containing raster data.
+    Convert 2D numpy array containing raster data into polygons.
+
+    This implementation uses rasterio.features.shapes, which uses GDALpolygonize
+    under the hood.
+
+    References:
+    (1) https://rasterio.readthedocs.io/en/latest/api/rasterio.features.html
+    (2) https://gdal.org/programs/gdal_polygonize.html
 
     Args:
         data_array (np.ndarray): 2D numpy array with the raster data.
-        mask (Optional[np.ndarray], optional): Boolean mask that can be applied
-        over the polygonisation. Defaults to None.
+        mask (Optional[np.ndarray], optional): Boolean mask that can be applied.
+        Values of False or 0 will be excluded from feature generation. Must
+        evaluate to bool.
         connectivity (int, optional): Use 4 or 8 pixel connectivity for grouping
         pixels into features. 8 can cause issues, Defaults to 4.
         apply_buffer (bool, optional): Apply shapely buffer function to the

--- a/src/data_loading/rasterio_utils.py
+++ b/src/data_loading/rasterio_utils.py
@@ -1,51 +1,56 @@
-"""A collection of utility functions for data loading with rasterio"""
+"""A collection of utility functions for data loading with rasterio."""
 
-from typing import Optional, Union, Iterable, Tuple
+from typing import Iterable, Optional, Tuple, Union
+
+import affine
+import geopandas as gpd
 import numpy as np
-from rasterio.io import DatasetReader
 from rasterio.crs import CRS
+from rasterio.features import shapes
+from rasterio.io import DatasetReader
 
 
 class CoordinateSystemError(Exception):
-    """Basic exception for coordinate system errors"""
+    """Basic exception for coordinate system errors."""
 
 
 class InvalidUseError(Exception):
-    """Basic exception for invalid usage of functions"""
+    """Basic exception for invalid usage of functions."""
 
 
 def get_thumbnail(
     data: DatasetReader,
     band_idx: Optional[int] = 1,
-    height: Optional[int] = 100,
+    height: Optional[int] = None,
     width: Optional[int] = None,
 ) -> np.ndarray:
     """
-    Calculate a thumbnail for a given band of a rasterio data
+    Calculate a thumbnail for a given band of a rasterio data.
 
     Args:
         data (DatasetReader): rasterio data handle
-        band_idx (Optional[int], optional): The band index for which to caluclate the
-            thumbnail. Defaults to 1.
-        height (Optional[int], optional): The desired height of the thumbnail.
-            If only the height is set, the width will be automatically determined
-            from the datas aspect ratio. Defaults to 100.
-        width (Optional[int], optional): The desired width of the thumbnail.
-            Defaults to None.
+        band_idx (int, optional): The band index for which to calculate the
+        thumbnail. Defaults to 1.
+        height (int, optional): The desired height of the thumbnail. If only the
+        height is set, the width will be automatically determined from the datas
+        aspect ratio. Defaults to 100.
+        width (int, optional): The desired width of the thumbnail. Defaults to
+        None.
 
     Returns:
         np.ndarray: The 2D numpy array representing the thumbnail as calculated
             from nearest neighbour resampling.
     """
-
     aspect_ratio = data.height / data.width
-
-    if height and not width:
+    if not height and not width:
+        height = 100
+    elif height and not width:
         width = int(height / aspect_ratio)
     elif width and not height:
         height = int(width * aspect_ratio)
 
-    assert height > 0 and width > 0, "Output height and/or width must be specified."
+    # Output height and/or width must be specified.
+    assert height > 0 and width > 0
 
     return data.read(band_idx, out_shape=(int(height), int(width)))
 
@@ -53,8 +58,8 @@ def get_thumbnail(
 def read_from_lat_lon(
     data: DatasetReader,
     band_idxs: Union[int, Iterable[int]],
-    lat: Tuple[float],
-    lon: Tuple[float],
+    lat: Tuple[float, float],
+    lon: Tuple[float, float],
     **kwargs,
 ) -> np.ndarray:
     """
@@ -106,3 +111,46 @@ def read_from_lat_lon(
     return data.read(
         indexes=band_idxs, window=((row_min, row_max), (col_min, col_max)), **kwargs
     )
+
+
+def polygonise(
+    data_array: np.ndarray,
+    mask: Optional[np.ndarray] = None,
+    connectivity: int = 4,
+    apply_buffer: bool = True,
+    transform: affine.Affine = affine.identity,
+    crs: Optional[str] = None,
+):
+    """
+    Polygonise 2D numpy array containing raster data.
+
+    Args:
+        data_array (np.ndarray): 2D numpy array with the raster data.
+        mask (Optional[np.ndarray], optional): Boolean mask that can be applied
+        over the polygonisation. Defaults to None.
+        connectivity (int, optional): Use 4 or 8 pixel connectivity for grouping
+        pixels into features. 8 can cause issues, Defaults to 4.
+        apply_buffer (bool, optional): Apply shapely buffer function to the
+        polygons after polygonising. This can fix issues with the polygonisation
+        creating invalid geometries.
+        transform (affine.Affine, optional): Affine transformation to apply
+        when polygonising. Defaults to the identity transform.
+        crs (Optional[str], optional): Coordinate reference system to set on the
+        resulting dataframe. Defaults to None.
+
+    Returns:
+        gpd.GeoDataFrame: GeoDataFrame containing polygon objects.
+    """
+    poly_generator = shapes(
+        data_array, mask=mask, connectivity=connectivity, transform=transform
+    )
+    results = list(
+        {"properties": {"class_label": int(val)}, "geometry": shape}
+        for shape, val in poly_generator
+    )
+    df = gpd.GeoDataFrame.from_features(results, crs=crs)
+    if apply_buffer:
+        # Redraw geometries to ensure polygons are valid.
+        df.geometry = df.geometry.buffer(0)
+
+    return df

--- a/src/data_loading/rasterio_utils.py
+++ b/src/data_loading/rasterio_utils.py
@@ -42,11 +42,11 @@ def get_thumbnail(
             from nearest neighbour resampling.
     """
     aspect_ratio = data.height / data.width
-    if not height and not width:
+    if height is None and width is None:
         height = 100
-    elif height and not width:
+    elif height is not None and width is None:
         width = int(height / aspect_ratio)
-    elif width and not height:
+    elif width is not None and height is None:
         height = int(width * aspect_ratio)
 
     # Output height and/or width must be specified.
@@ -115,11 +115,11 @@ def read_from_lat_lon(
 
 def polygonise(
     data_array: np.ndarray,
-    mask: Optional[np.ndarray] = None,
+    mask: Optional[np.ndarray],
+    transform: affine.Affine,
+    crs: Optional[str],
     connectivity: int = 4,
     apply_buffer: bool = True,
-    transform: affine.Affine = affine.identity,
-    crs: Optional[str] = None,
 ):
     """
     Convert 2D numpy array containing raster data into polygons.
@@ -133,18 +133,18 @@ def polygonise(
 
     Args:
         data_array (np.ndarray): 2D numpy array with the raster data.
-        mask (Optional[np.ndarray], optional): Boolean mask that can be applied.
-        Values of False or 0 will be excluded from feature generation. Must
-        evaluate to bool.
-        connectivity (int, optional): Use 4 or 8 pixel connectivity for grouping
-        pixels into features. 8 can cause issues, Defaults to 4.
-        apply_buffer (bool, optional): Apply shapely buffer function to the
-        polygons after polygonising. This can fix issues with the polygonisation
-        creating invalid geometries.
+        mask (np.ndarray, optional): Boolean mask that can be applied over
+        the polygonisation. Defaults to None.
         transform (affine.Affine, optional): Affine transformation to apply
         when polygonising. Defaults to the identity transform.
-        crs (Optional[str], optional): Coordinate reference system to set on the
+        crs (str, optional): Coordinate reference system to set on the
         resulting dataframe. Defaults to None.
+        connectivity (int, optional): Use 4 or 8 pixel connectivity for
+        grouping pixels into features. 8 can cause issues, Defaults to 4.
+        apply_buffer (bool, optional): Apply shapely buffer function to the
+        polygons after polygonising. This can fix issues with the
+        polygonisation creating invalid geometries.
+
 
     Returns:
         gpd.GeoDataFrame: GeoDataFrame containing polygon objects.

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -213,6 +213,8 @@ class GeoGraph:
         """
         Load raster data from a GeoTiff file, then load graph and rtree.
 
+        Note: Assumes that relevant data is stored in the first band (band 1) by default.
+
         Args:
             raster_path (pathlib.Path): A path to a file of raster data in
             GeoTiff format.

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -1,7 +1,11 @@
 """Module for processing and analysis of the graph generated from shp files."""
 
+import bz2
+import gzip
 import os
 import pathlib
+import pickle
+from itertools import zip_longest
 from typing import Dict, List, Optional, Union
 
 import geopandas as gpd
@@ -9,7 +13,9 @@ import networkx as nx
 import rasterio
 import shapely
 from rasterio.features import shapes
+from shapely.ops import unary_union
 from shapely.strtree import STRtree
+from src.constants import PROJECT_PATH
 from tqdm import tqdm
 
 
@@ -20,38 +26,59 @@ class GeoGraph:
         self,
         dataframe: Optional[gpd.GeoDataFrame] = None,
         graph_load_path: Optional[Union[str, os.PathLike]] = None,
-        # graph_save_path: Optional[Union[str, os.PathLike]] = None,
+        graph_save_path: Optional[Union[str, os.PathLike]] = None,
+        raster_load_path: Optional[Union[str, os.PathLike]] = None,
+        raster_save_path: Optional[Union[str, os.PathLike]] = None,
         vector_path: Optional[Union[str, os.PathLike]] = None,
-        raster_path: Optional[Union[str, os.PathLike]] = None,
     ) -> None:
         """
         Class for the fragmentation graph.
 
         This class can load a pickled networkx graph directly, or create the
-        graph from a shape file or dataframe.
+        graph from vector data, raster data, or a dataframe containing polygons.
 
         Args:
             dataframe (gpd.GeoDataFrame, optional): A geopandas dataframe
-            object. Defaults to None.
-            graph_load_path (str or pathlib.Path, optional): A path to a pickled
-            networkx graph. Defaults to None.
+            object containing a `geometry` column with polygon data. To load
+            polygon class labels as node attributes, include these in a column.
+            Defaults to None.
+            graph_load_path (str or pathlib.Path, optional): A path to a pickle
+            file to load from, can be `.gz` or `.bz2`. Defaults to None.
             graph_save_path (str or pathlib.Path, optional): A path to a pickle
-            file to save the graph to, can be `.gz` or `.bz2`. Defaults to None.
+            file to save the graph to, can be `.gz` or `.bz2`. Defaults to None,
+            which will save the graph in the project root in the `data`
+            folder.
             vector_path (str or pathlib.Path, optional): A path to a file of
-            vector data, either in GPKG or shapefile format. Defaults to None.
-            raster_path (str or pathlib.Path, optional): A path to a file of
-            raster data in GeoTiff format. Defaults to None.
+            vector data, either in GPKG or Shapefile format. Defaults to None.
+            raster_load_path (str or pathlib.Path, optional): A path to a file
+            of raster data in GeoTiff format. Defaults to None.
+            raster_save_path (str or pathlib.Path, optional): A path to a file
+            to save the polygonised raster data in. A path to a GPKG file is
+            recommended, but Shapefiles also work. Defaults to None, which saves
+            to the project root in the `data` folder in GPKG format.
         """
         super().__init__()
         self._graph = nx.Graph()
+        if graph_save_path is None:
+            graph_save_path = PROJECT_PATH / "data" / "geograph.bz2"
+            os.makedirs(graph_save_path.parent, exist_ok=True)
+        if raster_save_path is None:
+            raster_save_path = PROJECT_PATH / "data" / "geo_data.gpkg"
+            os.makedirs(raster_save_path.parent, exist_ok=True)
+
         if graph_load_path is not None:
-            self._load_graph(pathlib.Path(graph_load_path))
+            self._rtree = self._load_graph(pathlib.Path(graph_load_path))
         elif dataframe is not None:
             self._rtree = self._dataframe_to_graph(dataframe)
+            self._save_graph(pathlib.Path(graph_save_path))
         elif vector_path is not None:
             self._rtree = self._load_vector(pathlib.Path(vector_path))
-        elif raster_path is not None:
-            self._rtree = self._load_raster(pathlib.Path(raster_path))
+            self._save_graph(pathlib.Path(graph_save_path))
+        elif raster_load_path is not None:
+            self._rtree = self._load_raster(
+                pathlib.Path(raster_load_path), pathlib.Path(raster_save_path)
+            )
+            self._save_graph(pathlib.Path(graph_save_path))
 
     @property
     def graph(self) -> nx.Graph:
@@ -67,53 +94,142 @@ class GeoGraph:
         """Return Rtree object."""
         return self._rtree
 
-    def _load_vector(self, vector_path: pathlib.Path) -> STRtree:
+    def _load_vector(self, vector_path: pathlib.Path, load_slice=None) -> STRtree:
         """
-        Load GeoDataFrame with vector data from GeoPackage or shape file.
+        Load graph and rtree with vector data from GeoPackage or shape file.
 
         Args:
             vector_path (pathlib.Path): Path to a gpkg or shp file.
+            load_slice : A slice object denoting the rows of the dataframe to load.
+            Defaults to None, meaning load all rows.
+
+        Raises:
+            ValueError: If `vector_path` is not a GPKG or Shapefile.
+
+        Returns:
+            STRtree: The Rtree object used to build the graph.
         """
         if vector_path.suffix not in (".shp", ".gpkg"):
-            raise ValueError("Argument `vector_path` should be a GPKG or shapefile.")
+            raise ValueError("Argument `vector_path` should be a GPKG or Shapefile.")
         # First try to load as GeoPackage, then as Shapefile.
-        dataframe = gpd.read_file(
-            vector_path, enabled_drivers=["GPKG", "ESRI Shapefile"]
-        )
+        if slice is not None:
+            dataframe = gpd.read_file(
+                vector_path, rows=load_slice, enabled_drivers=["GPKG", "ESRI Shapefile"]
+            )
+        else:
+            dataframe = gpd.read_file(
+                vector_path, enabled_drivers=["GPKG", "ESRI Shapefile"]
+            )
         return self._dataframe_to_graph(dataframe)
 
-    def _load_raster(self, raster_path: pathlib.Path) -> STRtree:
-        """Load raster."""
+    def _load_raster(
+        self, raster_path: pathlib.Path, save_path: pathlib.Path
+    ) -> STRtree:
+        """
+        Load raster data, polygonize, then load graph and rtree.
+
+        The raster data should be in GeoTiff format.
+
+        Args:
+            raster_path (pathlib.Path): A path to a file of raster data in
+            GeoTiff format.
+            save_path (pathlib.Path, optional): A path to a file to save the
+            polygonised raster data in. A path to a GPKG file is recommended,
+            but Shapefiles also work.
+
+        Raises:
+            ValueError: If `save_path` is not a GPKG or Shapefile.
+
+        Returns:
+            STRtree: The Rtree object used to build the graph.
+        """
+        if save_path.suffix not in (".shp", ".gpkg"):
+            raise ValueError("Argument `save_path` should be a GPKG or Shapefile.")
         mask = None
         with rasterio.Env():
             with rasterio.open(raster_path) as image:
-                image_band_1 = image.read(1)  # first band
-                results = (
+                image_band_1 = image.read(1)
+                geoms = [
                     {"properties": {"raster_val": v}, "geometry": s}
-                    for i, (s, v) in enumerate(
-                        shapes(image_band_1, mask=mask, transform=image.transform)
+                    for _, (s, v) in enumerate(
+                        shapes(
+                            image_band_1,
+                            mask=mask,
+                            connectivity=4,
+                            transform=image.transform,
+                        )
                     )
-                )
-        geoms = list(results)
-        gpd_polygonized_raster = gpd.GeoDataFrame.from_features(geoms)
-        # gpd_polygonized_raster.to_file(output_geojson_path, driver='GPKG')
-        return self._dataframe_to_graph(gpd_polygonized_raster)
+                ]
+        vector_df = gpd.GeoDataFrame.from_features(geoms)
+        # Redraw geometries to ensure polygons are valid.
+        vector_df.geometry = vector_df.geometry.buffer(0)
 
-    def _load_graph(self, graph_path: pathlib.Path) -> None:
+        if save_path.suffix == ".gpkg":
+            vector_df.to_file(save_path, driver="GPKG")
+        else:
+            vector_df.to_file(save_path)
+        return self._dataframe_to_graph(vector_df, attributes=["geometry"])
+
+    def _load_graph(self, graph_path: pathlib.Path) -> STRtree:
         """
-        Load networkx graph object from a pickle file.
+        Load networkx graph and rtree objects from a pickle file.
 
         Args:
-            graph_path (pathlib.Path): Path to a pickle file.
+            graph_path (pathlib.Path): Path to a pickle file. Can be compressed
+            with gzip or bz2.
+
+        Raises:
+            ValueError: If `graph_path` is not a pickle, bz2, or gz file.
+
+        Returns:
+            STRtree: The Rtree object used to build the graph.
         """
         if graph_path.suffix not in (".pickle", ".pkl", ".gz", ".bz2"):
             raise ValueError("Argument `graph_path` should be a pickle file.")
-        self.graph = nx.read_gpickle(graph_path)
 
-    def _save_graph(self, save_path: str) -> None:
-        """Save graph with attributes as pickle file. Can be compressed."""
-        # TODO: save Rtree
-        nx.write_gpickle(self.graph, save_path)
+        if graph_path.suffix == ".bz2":
+            bz2_file = bz2.BZ2File(graph_path, "rb")
+            data = pickle.load(bz2_file)
+            bz2_file.close()
+        elif graph_path.suffix == ".gz":
+            gz_file = gzip.GzipFile(graph_path, "rb")
+            gz_data = gz_file.read()
+            data = pickle.loads(gz_data)
+            gz_file.close()
+        else:
+            with open(graph_path, "rb") as file:
+                data = pickle.load(file)
+
+        self.graph = data["graph"]
+        return data["rtree"]
+
+    def _save_graph(self, save_path: pathlib.Path) -> None:
+        """
+        Save graph with attributes and rtree as pickle file. Can be compressed.
+
+        Args:
+            save_path (pathlib.Path): Path to a pickle file. Can be compressed
+            with gzip or bz2 by passing filenames ending in `gz` or `bz2`.
+
+        Raises:
+            ValueError: If `save_path` is not a pickle, bz2, or gz file path.
+        """
+        if save_path.suffix not in (".pickle", ".pkl", ".gz", ".bz2"):
+            raise ValueError(
+                "Argument `save_path` should be a pickle file or compressed file."
+            )
+
+        data = {"graph": self.graph, "rtree": self.rtree}
+        if save_path.suffix == ".bz2":
+            with bz2.BZ2File(save_path, "wb") as bz2_file:
+                pickle.dump(data, bz2_file)
+        elif save_path.suffix == ".gz":
+            gz_file = gzip.GzipFile(save_path, "wb")
+            gz_file.write(pickle.dumps(data))
+            gz_file.close()
+        else:
+            with open(save_path, "wb") as file:
+                pickle.dump(data, file)
 
     def _dataframe_to_graph(
         self, df: gpd.GeoDataFrame, attributes: Optional[List[str]] = None
@@ -186,3 +302,49 @@ class GeoGraph:
                 self.graph.add_edge(polygon_id, neighbour_id)
 
         return tree
+
+    def merge_nodes(self, node_list: List[int], final_index: int = None) -> None:
+        """
+        Merge a list of nodes in the graph together into a single node.
+
+        This will create a node with a neighbour list and polygon which is the
+        union of the nodes in `node_list`.
+
+        Args:
+            node_list (List[int]): List of integer node indexes in the graph.
+            final_index (int, optional): Index to assign to the resulting node.
+            Defaults to None, in which case it becomes the number of nodes in
+            the graph.
+
+        Raises:
+            ValueError: If there are invalid nodes in `node_list`, or if
+            `final_index` is an existing node not in `node_list`.
+        """
+        if not all(self.graph.has_node(node) for node in node_list):
+            raise ValueError("`node_list` must only contain valid nodes.")
+        if (
+            final_index is not None
+            and final_index not in node_list
+            and self.graph.has_node(final_index)
+        ):
+            raise ValueError(
+                "`final_index` must not be an existing node not in `node_list`."
+            )
+        if final_index is None:
+            final_index = self.graph.number_of_nodes
+        adjacency_list = set()
+        for node in node_list:
+            adjacency_list.update(self.graph.neighbors(node))
+        polygon = unary_union(
+            [self.graph.nodes[node]["geometry"] for node in node_list]
+        )
+        self.graph.remove_nodes_from(node_list)
+        self.graph.add_node(
+            final_index,
+            rep_point=polygon.representative_point(),
+            area=polygon.area,
+            perimeter=polygon.length,
+        )
+        self.graph.add_edges_from(
+            zip_longest([final_index], adjacency_list, fillvalue=final_index)
+        )

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -47,7 +47,7 @@ class GeoGraph:
         """
         if not graph_path.endswith(('pickle', 'pkl')):
             raise ValueError("Argument `graph_path` should be a pickle file.")
-        self.G = nx.read_gpickle(graph_path)
+        self.graph = nx.read_gpickle(graph_path)
 
     def _dataframe_to_graph(self, df: gpd.GeoDataFrame, attributes: Optional[List[str]] = None) -> None:
         """

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -120,7 +120,7 @@ class GeoGraph:
             neighbours: List[int] = [
                 id_dict[id(nbr)]
                 for nbr in tree.query(polygon)
-                if nbr.touches(polygon) or nbr.overlaps(polygon)
+                if nbr.intersects(polygon) and id_dict[id(nbr)] != id_dict[id(polygon)]
             ]
             # this dict maps polygon indices in df to a list
             # of neighbouring polygon indices

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -52,8 +52,11 @@ class GeoGraph:
         Class for the fragmentation graph.
 
         This class can load a pickled networkx graph directly, or create the
-        graph from a path to vector data, a path to raster data, a numpy array
-        containing raster data, or a dataframe containing polygons.
+        graph from 
+            - a path to vector data (.shp, .gpkg)
+            - a path to raster data  (.tif, .tiff, .geotif, .geotiff)
+            - a numpy array containing raster data
+            - a dataframe containing polygons.
 
         Note that when loading vector data, the class label column may not be
         named "class_label", which will cause an error. If loading from a

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -1,4 +1,8 @@
-"""Module for processing and analysis of the geospatial graph."""
+"""
+Module for processing and analysis of the geospatial graph.
+
+See https://networkx.org/documentation/stable/index.html for graph operations.
+"""
 
 import bz2
 import gzip
@@ -8,7 +12,6 @@ import pickle
 from itertools import zip_longest
 from typing import Dict, List, Optional, Union
 
-import affine
 import geopandas as gpd
 import networkx as nx
 import numpy as np
@@ -16,9 +19,21 @@ import rasterio
 import shapely
 from shapely.ops import unary_union
 from shapely.strtree import STRtree
-from src.constants import PROJECT_PATH
 from src.data_loading.rasterio_utils import polygonise
 from tqdm import tqdm
+
+VALID_EXTENSIONS = (
+    ".pickle",
+    ".pkl",
+    ".gz",
+    ".bz2",
+    ".shp",
+    ".gpkg",
+    ".tiff",
+    ".tif",
+    ".geotif",
+    ".geotiff",
+)
 
 
 class GeoGraph:
@@ -26,24 +41,25 @@ class GeoGraph:
 
     def __init__(
         self,
-        dataframe: Optional[gpd.GeoDataFrame] = None,
+        data,
         attributes: Optional[List[str]] = None,
-        graph_load_path: Optional[Union[str, os.PathLike]] = None,
         graph_save_path: Optional[Union[str, os.PathLike]] = None,
-        raster_array: Optional[np.ndarray] = None,
-        raster_load_path: Optional[Union[str, os.PathLike]] = None,
         raster_save_path: Optional[Union[str, os.PathLike]] = None,
-        vector_path: Optional[Union[str, os.PathLike]] = None,
         tolerance: float = 0.0,
-        mask: Optional[np.ndarray] = None,
-        transform: affine.Affine = affine.identity,
-        crs: Optional[str] = None,
+        **kwargs,
     ) -> None:
         """
         Class for the fragmentation graph.
 
         This class can load a pickled networkx graph directly, or create the
-        graph from vector data, raster data, or a dataframe containing polygons.
+        graph from a path to vector data, a path to raster data, a numpy array
+        containing raster data, or a dataframe containing polygons.
+
+        Note that when loading vector data, the class label column may not be
+        named "class_label", which will cause an error. If loading from a
+        dataframe, it must contain a column with this name. Dataframes must also
+        contain a "geometry" column containing the polygon data.
+
         Warning: loading and saving GeoGraphs uses pickle. Loading untrusted
         data using the pickle module is not secure as it can execute arbitrary
         code. Therefore, only load GeoGraphs that come from a trusted source.
@@ -51,68 +67,87 @@ class GeoGraph:
         https://docs.python.org/3/library/pickle.html
 
         Args:
-            dataframe (gpd.GeoDataFrame, optional): A geopandas dataframe
-            object containing a `geometry` column with polygon data. To load
-            polygon class labels as node attributes, include these in a column.
-            Defaults to None.
-            attributes (Optional[List[str]], optional): columns of dataframe
+            data: Can be a path to a pickle file or compressed pickle file to load
+            the graph from, a path to vector data in GPKG or Shapefile format,
+            a path to raster data in GeoTiff format, a numpy array containing raster
+            data, or a dataframe containing polygons.
+            attributes (Optional[List[str]], optional): Columns of the dataframe
             that are added to nodes of graph as attributes. Defaults to None,
             which will cause all attributes to be added.
-            graph_load_path (str or pathlib.Path, optional): A path to a pickle
-            file to load from, can be `.gz` or `.bz2`. Defaults to None.
             graph_save_path (str or pathlib.Path, optional): A path to a pickle
             file to save the graph to, can be `.gz` or `.bz2`. Defaults to None,
-            which will save the graph in the project root in the `data`
-            folder.
-            raster_array (np.ndarray, optional): 2D numpy array with the raster
-            data that can be passed as an alternative to `raster_path`.
-            vector_path (str or pathlib.Path, optional): A path to a file of
-            vector data, either in GPKG or Shapefile format. Defaults to None.
-            raster_load_path (str or pathlib.Path, optional): A path to a file
-            of raster data in GeoTiff format. Defaults to None.
+            which will not save the graph.
             raster_save_path (str or pathlib.Path, optional): A path to a file
             to save the polygonised raster data in. A path to a GPKG file is
-            recommended, but Shapefiles also work. Defaults to None, which saves
-            to the project root in the `data` folder in GPKG format.
+            recommended, but Shapefiles also work. Defaults to None, which will
+            not save the polygonised data.
             tolerance (float, optional): Adds edges between neighbours that are
             at most `tolerance` units apart. Defaults to 0.
-            mask (np.ndarray, optional): Boolean mask that can be applied over
+
+            **mask (np.ndarray, optional): Boolean mask that can be applied over
             the polygonisation. Defaults to None.
-            transform (affine.Affine, optional): Affine transformation to apply
-            when polygonising. Defaults to the identity transform.
-            crs (str, optional): Coordinate reference system to set on the
+            **transform (affine.Affine, optional): Affine transformation to
+            apply when polygonising. Defaults to the identity transform.
+            **crs (str, optional): Coordinate reference system to set on the
             resulting dataframe. Defaults to None.
+            **connectivity (int, optional): Use 4 or 8 pixel connectivity for
+            grouping pixels into features. 8 can cause issues, Defaults to 4.
+            **apply_buffer (bool, optional): Apply shapely buffer function to
+            the polygons after polygonising. This can fix issues with the
+            polygonisation creating invalid geometries.
         """
         super().__init__()
         self._graph = nx.Graph()
-        if graph_save_path is None:
-            graph_save_path = PROJECT_PATH / "data" / "geograph.bz2"
-            os.makedirs(graph_save_path.parent, exist_ok=True)
-        if raster_save_path is None:
-            raster_save_path = PROJECT_PATH / "data" / "geo_data.gpkg"
+
+        if raster_save_path is not None:
+            raster_save_path = pathlib.Path(raster_save_path)
+            if raster_save_path.suffix not in (".shp", ".gpkg"):
+                raise ValueError("Argument `save_path` should be a GPKG or Shapefile.")
             os.makedirs(raster_save_path.parent, exist_ok=True)
         self.tolerance: float = tolerance
+        load_from_graph: bool = False
 
-        if graph_load_path is not None:
-            self._rtree = self._load_graph(pathlib.Path(graph_load_path))
-        elif dataframe is not None:
-            self._rtree = self._dataframe_to_graph(
-                dataframe, attributes, tolerance=self.tolerance
+        # Load from disk
+        if isinstance(data, (str, os.PathLike)):
+            load_path = pathlib.Path(data)
+            assert load_path.exists()
+            # Load from saved graph
+            if load_path.suffix in (".pickle", ".pkl", ".gz", ".bz2"):
+                self._rtree = self._load_from_graph_path(load_path)
+                load_from_graph = True
+            # Load from saved vector data
+            elif load_path.suffix in (".shp", ".gpkg"):
+                self._rtree = self._load_from_vector_path(load_path, attributes)
+            # Load from saved raster data
+            elif load_path.suffix in (".tiff", ".tif", ".geotif", ".geotiff"):
+                self._rtree = self._load_from_raster_path(
+                    load_path, raster_save_path, **kwargs
+                )
+            else:
+                raise ValueError(
+                    f"""Extension {load_path.suffix} unknown.
+                                 Must be one of {VALID_EXTENSIONS}"""
+                )
+
+        # Load from objects in memory
+        # Load from dataframe
+        elif isinstance(data, gpd.GeoDataFrame):
+            self._rtree = self._load_from_dataframe(
+                data, attributes, tolerance=self.tolerance
             )
-            self._save_graph(pathlib.Path(graph_save_path))
-        elif raster_array is not None or raster_load_path is not None:
-            self._rtree = self._load_raster(
-                raster_load_path,
-                pathlib.Path(raster_save_path),
-                array=raster_array,
-                mask=mask,
-                transform=transform,
-                crs=crs,
-            )
-            self._save_graph(pathlib.Path(graph_save_path))
-        elif vector_path is not None:
-            self._rtree = self._load_vector(pathlib.Path(vector_path), attributes)
-            self._save_graph(pathlib.Path(graph_save_path))
+        # Load from raster array
+        elif isinstance(data, np.ndarray):
+            self._rtree = self._load_from_raster(data, raster_save_path, **kwargs)
+        # Save resulting graph, if we didn't load from graph.
+        if not load_from_graph and graph_save_path is not None:
+            graph_save_path = pathlib.Path(graph_save_path)
+            if graph_save_path.suffix not in (".pickle", ".pkl", ".gz", ".bz2"):
+                raise ValueError(
+                    """Argument `graph_save_path` should be a pickle file or
+                    compressed file."""
+                )
+            os.makedirs(graph_save_path.parent, exist_ok=True)
+            self._save_graph(graph_save_path)
 
         print(
             f"Graph successfully loaded with {self.graph.number_of_nodes()} nodes",
@@ -133,7 +168,7 @@ class GeoGraph:
         """Return Rtree object."""
         return self._rtree
 
-    def _load_vector(
+    def _load_from_vector_path(
         self,
         vector_path: pathlib.Path,
         attributes: Optional[List[str]] = None,
@@ -150,14 +185,9 @@ class GeoGraph:
             load_slice: A slice object denoting the rows of the dataframe to
             load. Defaults to None, meaning load all rows.
 
-        Raises:
-            ValueError: If `vector_path` is not a GPKG or Shapefile.
-
         Returns:
             STRtree: The Rtree object used to build the graph.
         """
-        if vector_path.suffix not in (".shp", ".gpkg"):
-            raise ValueError("Argument `vector_path` should be a GPKG or Shapefile.")
         # First try to load as GeoPackage, then as Shapefile.
         if slice is not None:
             dataframe = gpd.read_file(
@@ -167,18 +197,37 @@ class GeoGraph:
             dataframe = gpd.read_file(
                 vector_path, enabled_drivers=["GPKG", "ESRI Shapefile"]
             )
-        return self._dataframe_to_graph(
+        return self._load_from_dataframe(
             dataframe, attributes=attributes, tolerance=self.tolerance
         )
 
-    def _load_raster(
+    def _load_from_raster_path(
         self,
-        raster_path: Optional[Union[str, os.PathLike]],
-        save_path: pathlib.Path,
-        array: Optional[np.ndarray],
-        mask: Optional[np.ndarray],
-        transform: affine.Affine,
-        crs: Optional[str],
+        raster_path: pathlib.Path,
+        save_path: Optional[pathlib.Path],
+        **raster_kwargs,
+    ) -> STRtree:
+        """
+        Load raster data from a GeoTiff file, then load graph and rtree.
+
+        Args:
+            raster_path (pathlib.Path): A path to a file of raster data in
+            GeoTiff format.
+            save_path (pathlib.Path, optional): A path to a file to save the
+            polygonised raster data in. A path to a GPKG file is recommended,
+            but Shapefiles also work.
+
+        Returns:
+            STRtree: The Rtree object used to build the graph.
+        """
+        with rasterio.Env():
+            with rasterio.open(raster_path) as image:
+                # Load band 1
+                data = image.read(1)
+        return self._load_from_raster(data, save_path, **raster_kwargs)
+
+    def _load_from_raster(
+        self, data_array: np.ndarray, save_path: Optional[pathlib.Path], **raster_kwargs
     ) -> STRtree:
         """
         Load raster data, polygonise, then load graph and rtree.
@@ -191,59 +240,25 @@ class GeoGraph:
         (2) https://gdal.org/programs/gdal_polygonize.html
 
         Args:
-            raster_path (pathlib.Path): A path to a file of raster data in
-            GeoTiff format.
+            data_array (np.ndarray): 2D numpy array with the raster data.
             save_path (pathlib.Path, optional): A path to a file to save the
             polygonised raster data in. A path to a GPKG file is recommended,
             but Shapefiles also work.
-            array (np.ndarray, optional): 2D numpy array with the raster data
-            that can be passed as an alternative to `raster_path`.
-            mask (np.ndarray, optional): Boolean mask that can be applied over
-            the polygonisation. Defaults to None.
-            transform (affine.Affine, optional): Affine transformation to apply
-            when polygonising. Defaults to the identity transform.
-            crs (str, optional): Coordinate reference system to set on the
-            resulting dataframe. Defaults to None.
-
-        Raises:
-            ValueError: If `save_path` is not a GPKG or Shapefile, or if both
-            `raster_path` and `array` are None, or if `raster_path` is not a
-            GeoTiff file.
 
         Returns:
             STRtree: The Rtree object used to build the graph.
         """
-        if save_path.suffix not in (".shp", ".gpkg"):
-            raise ValueError("Argument `save_path` should be a GPKG or Shapefile.")
-        if array is None and raster_path is None:
-            raise ValueError("One of `raster_path` or `array` arguments must be used.")
-        elif array is None and raster_path is not None:
-            raster_path = pathlib.Path(raster_path)
-            if raster_path.suffix not in (".tiff", ".tif", ".geotif"):
-                raise ValueError("Argument `raster_path` should be a GeoTiff file.")
-            with rasterio.Env():
-                with rasterio.open(raster_path) as image:
-                    data = image.read(1)  # Read band 1
-        else:
-            data = array
-        vector_df = polygonise(
-            data_array=data,
-            mask=mask,
-            connectivity=4,
-            apply_buffer=True,
-            transform=transform,
-            crs=crs,
-        )
-
-        if save_path.suffix == ".gpkg":
-            vector_df.to_file(save_path, driver="GPKG")
-        else:
-            vector_df.to_file(save_path)
-        return self._dataframe_to_graph(
+        vector_df = polygonise(data_array=data_array, **raster_kwargs)
+        if save_path is not None:
+            if save_path.suffix == ".gpkg":
+                vector_df.to_file(save_path, driver="GPKG")
+            else:
+                vector_df.to_file(save_path, driver="ESRI Shapefile")
+        return self._load_from_dataframe(
             vector_df, attributes=["geometry", "class_label"], tolerance=self.tolerance
         )
 
-    def _load_graph(self, graph_path: pathlib.Path) -> STRtree:
+    def _load_from_graph_path(self, graph_path: pathlib.Path) -> STRtree:
         """
         Load networkx graph and rtree objects from a pickle file.
 
@@ -251,15 +266,9 @@ class GeoGraph:
             graph_path (pathlib.Path): Path to a pickle file. Can be compressed
             with gzip or bz2.
 
-        Raises:
-            ValueError: If `graph_path` is not a pickle, bz2, or gz file.
-
         Returns:
             STRtree: The Rtree object used to build the graph.
         """
-        if graph_path.suffix not in (".pickle", ".pkl", ".gz", ".bz2"):
-            raise ValueError("Argument `graph_path` should be a pickle file.")
-
         if graph_path.suffix == ".bz2":
             with bz2.BZ2File(graph_path, "rb") as bz2_file:
                 data = pickle.load(bz2_file)
@@ -280,15 +289,7 @@ class GeoGraph:
         Args:
             save_path (pathlib.Path): Path to a pickle file. Can be compressed
             with gzip or bz2 by passing filenames ending in `gz` or `bz2`.
-
-        Raises:
-            ValueError: If `save_path` is not a pickle, bz2, or gz file path.
         """
-        if save_path.suffix not in (".pickle", ".pkl", ".gz", ".bz2"):
-            raise ValueError(
-                "Argument `save_path` should be a pickle file or compressed file."
-            )
-
         data = {"graph": self.graph, "rtree": self.rtree}
         if save_path.suffix == ".bz2":
             with bz2.BZ2File(save_path, "wb") as bz2_file:
@@ -300,7 +301,7 @@ class GeoGraph:
             with open(save_path, "wb") as file:
                 pickle.dump(data, file)
 
-    def _dataframe_to_graph(
+    def _load_from_dataframe(
         self,
         df: gpd.GeoDataFrame,
         attributes: Optional[List[str]] = None,
@@ -337,6 +338,12 @@ class GeoGraph:
             or "class_label" not in df.columns
         ):
             raise ValueError("`class_label` must be a column in the dataframe.")
+        if (
+            attributes is not None
+            and "geometry" not in attributes
+            or "geometry" not in df.columns
+        ):
+            raise ValueError("`geometry` must be a column in the dataframe.")
         # If no attribute list is given, all
         # columns in df are used
         if attributes is None:

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -207,7 +207,8 @@ class GeoGraph:
 
         Raises:
             ValueError: If `save_path` is not a GPKG or Shapefile, or if both
-            `raster_path` and `array` are None.
+            `raster_path` and `array` are None, or if `raster_path` is not a
+            GeoTiff file.
 
         Returns:
             STRtree: The Rtree object used to build the graph.
@@ -321,13 +322,21 @@ class GeoGraph:
             at most `tolerance` units apart. Defaults to 0.
 
         Raises:
-            ValueError: If `tolerance` < 0.
+            ValueError: If `tolerance` < 0, if `class_label` is not a column in
+            the dataframe, or if `attributes` contains column names not in the
+            dataframe.
 
         Returns:
             STRtree: The Rtree object used to build the graph.
         """
         if tolerance < 0.0:
             raise ValueError("`tolerance` must be greater than 0.")
+        if (
+            attributes is not None
+            and "class_label" not in attributes
+            or "class_label" not in df.columns
+        ):
+            raise ValueError("`class_label` must be a column in the dataframe.")
         # If no attribute list is given, all
         # columns in df are used
         if attributes is None:

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -225,7 +225,7 @@ class GeoGraph:
         """
         with rasterio.Env():
             with rasterio.open(raster_path) as image:
-                # Load band 1
+                # Load band 1 (Assumes that landcover map is stored in first band by default)
                 data = image.read(1)
         return self._load_from_raster(data, save_path, **raster_kwargs)
 

--- a/src/models/geotimeline.py
+++ b/src/models/geotimeline.py
@@ -1,0 +1,6 @@
+"""Module for analysing multiple GeoGraph objects."""
+
+
+class GeoGraphTimeline:
+    def __init__(self) -> None:
+        raise NotImplementedError


### PR DESCRIPTION
This PR contains all the loading code for `geograph.py`. You can load the graph from:

- a raster image, either passing a path to a GeoTiff file or a numpy array containing the data. This will polygonise using a function in `rasterio_utils.py`, using `connectivity=4` and `buffer(0)`. Then the vector data will be saved to a GPKG or Shapefile and loaded into a graph.
- a GPKG or Shapefile
- a GeoPandas dataframe
- a saved graph + rtree object, saved as a pickle file or compressed pickle file (`bz2` and `gzip` are supported)

After any of these,, the graph and rtree will be saved (by default to a `bz2` file since it has the highest compression).

The `_dataframe_to_graph()` function now also supports a `tolerance` parameter, which will create edges between all polygons which are within `tolerance` metres of each other. This is done by expanding the original polygon using `.buffer(tolerance)` and checking `intersects()`.

Each node's name is the integer index it had in the dataframe. By default, the node attributes are:

- a "representative point" for the polygon (see [here](https://shapely.readthedocs.io/en/stable/manual.html#object.representative_point))
- the polygon area
- the polygon perimeter
- the class label (when converting from raster)
- the polygon object itself, under node['geometry']

Additional attributes can be added by including them in a dataframe column (when passing a dataframe or when loading from a vector file). However, I strongly recommend we always use column names of `class_label` and `geometry` for the labels and polygons to keep things simple.

This PR also contains a `merge_nodes` function which accepts a list of nodes - this will create a new node with a neighbour list and polygon attribute which is the union of the nodes in the node list, while deleting all the old nodes.