### PR TITLE
Feature/graph-analysis-visualisation

### DIFF
--- a/src/models/visualisation.py
+++ b/src/models/visualisation.py
@@ -93,6 +93,7 @@ def create_graph_visualisation(
             fill_color="YlOrBr",
             name=name + "_polygons",
         )
+        choropleth = remove_choropleth_color_legend(choropleth)
         choropleth.add_to(folium_map)
 
         # adding popup markers with class name
@@ -212,3 +213,24 @@ def add_cez_to_map(
         folium.LayerControl().add_to(folium_map)
 
     return folium_map
+
+
+def remove_choropleth_color_legend(
+    choropleth_map: folium.features.Choropleth,
+) -> folium.features.Choropleth:
+    """Remove color legend from Choropleth folium map.
+
+    Solution proposed by `nhpackard` in the following GitHub issue in the folium repo:
+    https://github.com/python-visualization/folium/issues/956
+
+    Args:
+        choropleth_map (folium.features.Choropleth): a Choropleth map
+
+    Returns:
+        folium.features.Choropleth: the same map without color legend
+    """
+    for key in choropleth_map._children:  # pylint: disable=protected-access
+        if key.startswith("color_map"):
+            del choropleth_map._children[key]  # pylint: disable=protected-access
+
+    return choropleth_map


### PR DESCRIPTION
This tiny PR adds basic GeoGraphViewer functionality.

It currently is only built on the prior folium plotting functions, next step will be to redo it with ipyleaflet. I am planning to maintain the basic folium support because folium can be used on some platforms that don't support ipywidgets (and therefore ipyleaflet), like google colab. Also: plotting of polygons is not part of it yet and will be added once the df attribute is merged.

**Main Changes**
- Added GeoGraphViewer class

**Other Changes**
- fixed changed name for represenative point (to rep_point)
- removed choropleth color legend because not useful in our case.

**Demo of usage:**
![Screenshot 2021-02-25 at 10 48 27](https://user-images.githubusercontent.com/75615911/109143449-f0c16b80-7757-11eb-9a99-415051b1f764.png)
