### PR TITLE
Feature/graph analysis add_habitat function and get_graph_components function

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -39,6 +39,7 @@ geopy               # convenient API requests to geocoders
 
 # additional
 networkx            # manipulating graph data
+rtree               # rtree library
 
 # gdrive functionality
 google-api-python-client

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -50,7 +50,7 @@ class GeoGraph:
     def __init__(
         self,
         data,
-        crs: str,
+        crs: Union[str, pyproj.CRS], 
         graph_save_path: Optional[Union[str, os.PathLike]] = None,
         raster_save_path: Optional[Union[str, os.PathLike]] = None,
         columns_to_rename: Optional[Dict[str, str]] = None,
@@ -114,7 +114,7 @@ class GeoGraph:
         super().__init__()
         self.graph = nx.Graph()
         self._habitats: Dict[str, Habitat] = {}
-        self._crs: str = crs
+        self._crs: Union[str, pyproj.CRS] = crs
         self._columns_to_rename: Optional[Dict[str, str]] = columns_to_rename
         self._tolerance: float = tolerance
 

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -496,6 +496,7 @@ class GeoGraph:
         """
         if max_travel_distance < 0:
             raise ValueError("`max_travel_distance` must be greater than 0.")
+        valid_classes_set = set(valid_classes)
         hgraph: nx.Graph = deepcopy(self.graph)
         # Remove all edges in the graph, then at the end we only have edges
         # between nodes less than `max_travel_distance` apart
@@ -513,7 +514,7 @@ class GeoGraph:
         for node in tqdm(
             hgraph.nodes, desc="Generating habitat graph", total=len(hgraph)
         ):
-            if hgraph.nodes[node]["class_label"] not in valid_classes:
+            if hgraph.nodes[node]["class_label"] not in valid_classes_set:
                 invalid_indexes.append(node)
                 continue
 
@@ -525,7 +526,7 @@ class GeoGraph:
             # Query rtree for all polygons within `max_travel_distance` of the original
             for nbr in self.rtree.intersection(buff_poly.bounds):
                 # If a node is not a habitat class node, don't add the edge
-                if hgraph.nodes[nbr]["class_label"] not in valid_classes:
+                if hgraph.nodes[nbr]["class_label"] not in valid_classes_set:
                     continue
                 # Otherwise add the edge with distance attribute
                 nbr_polygon = polygons[nbr]

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -442,7 +442,7 @@ class GeoGraph:
             # add each polygon as a node to the graph with useful attributes
             self.graph.add_node(
                 index,
-                rep_point=polygon.representative_point().coords[0],
+                rep_point=polygon.representative_point(),
                 area=polygon.area,
                 perimeter=polygon.length,
                 class_label=class_labels[index],

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -565,7 +565,10 @@ class GeoGraph:
         This method takes an nx.Graph and determines the individual disconnected
         graph components that make up the graph. Each row of the returned
         GeoDataFrame corresponds to a graph component, with entries in column
-        'geometry' being the union of all individual polygons making up a component.
+        'geometry' being the union of all individual polygons making up a
+        component. Warning: this function can only be passed graphs which are a
+        subgraph of this class's main `graph` attribute, such as the habitat
+        subgraph or the main graph itself.
 
         This method allows for the UI to visualise components and output their
         number as a metric. Warning: this method is very slow if the graph
@@ -576,7 +579,8 @@ class GeoGraph:
         https://en.wikipedia.org/wiki/Component_(graph_theory)
 
         Args:
-            graph (nx.Graph): nx.Graph of a GeoGraph
+            graph (nx.Graph): nx.Graph object. This must be a subgraph of this
+            class's main `graph` attribute.
 
         Returns:
             Tuple: A tuple containing the resulting GeoDataFrame and the list of

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -3,12 +3,12 @@ Module for processing and analysis of the geospatial graph.
 
 See https://networkx.org/documentation/stable/index.html for graph operations.
 """
-
 import bz2
 import gzip
 import os
 import pathlib
 import pickle
+from copy import deepcopy
 from itertools import zip_longest
 from typing import Dict, List, Optional, Union
 
@@ -16,9 +16,9 @@ import geopandas as gpd
 import networkx as nx
 import numpy as np
 import rasterio
+import rtree as rtree_lib
 import shapely
 from shapely.ops import unary_union
-from shapely.strtree import STRtree
 from src.data_loading.rasterio_utils import polygonise
 from tqdm import tqdm
 
@@ -52,7 +52,7 @@ class GeoGraph:
         Class for the fragmentation graph.
 
         This class can load a pickled networkx graph directly, or create the
-        graph from 
+        graph from
             - a path to vector data (.shp, .gpkg)
             - a path to raster data  (.tif, .tiff, .geotif, .geotiff)
             - a numpy array containing raster data
@@ -101,6 +101,7 @@ class GeoGraph:
         """
         super().__init__()
         self._graph = nx.Graph()
+        self._habitats = {}
 
         if raster_save_path is not None:
             raster_save_path = pathlib.Path(raster_save_path)
@@ -167,16 +168,21 @@ class GeoGraph:
         self._graph = new_graph
 
     @property
-    def rtree(self) -> STRtree:
+    def rtree(self) -> rtree_lib.index.Index:
         """Return Rtree object."""
         return self._rtree
+
+    @property
+    def habitats(self) -> Dict[str, nx.Graph]:
+        """Return habitat dictionary."""
+        return self._habitats
 
     def _load_from_vector_path(
         self,
         vector_path: pathlib.Path,
         attributes: Optional[List[str]] = None,
         load_slice=None,
-    ) -> STRtree:
+    ) -> rtree_lib.index.Index:
         """
         Load graph and rtree with vector data from GeoPackage or shape file.
 
@@ -189,7 +195,7 @@ class GeoGraph:
             load. Defaults to None, meaning load all rows.
 
         Returns:
-            STRtree: The Rtree object used to build the graph.
+            rtree_lib.index.Index: The Rtree object used to build the graph.
         """
         # First try to load as GeoPackage, then as Shapefile.
         if slice is not None:
@@ -209,11 +215,12 @@ class GeoGraph:
         raster_path: pathlib.Path,
         save_path: Optional[pathlib.Path],
         **raster_kwargs,
-    ) -> STRtree:
+    ) -> rtree_lib.index.Index:
         """
         Load raster data from a GeoTiff file, then load graph and rtree.
 
-        Note: Assumes that relevant data is stored in the first band (band 1) by default.
+        Note: Assumes that relevant data is stored in the first band (band 1)
+        by default.
 
         Args:
             raster_path (pathlib.Path): A path to a file of raster data in
@@ -223,17 +230,17 @@ class GeoGraph:
             but Shapefiles also work.
 
         Returns:
-            STRtree: The Rtree object used to build the graph.
+            rtree_lib.index.Index: The Rtree object used to build the graph.
         """
         with rasterio.Env():
             with rasterio.open(raster_path) as image:
-                # Load band 1 (Assumes that landcover map is stored in first band by default)
+                # Load band 1 (Assumes that landcover map is in first band by default)
                 data = image.read(1)
         return self._load_from_raster(data, save_path, **raster_kwargs)
 
     def _load_from_raster(
         self, data_array: np.ndarray, save_path: Optional[pathlib.Path], **raster_kwargs
-    ) -> STRtree:
+    ) -> rtree_lib.index.Index:
         """
         Load raster data, polygonise, then load graph and rtree.
 
@@ -251,7 +258,7 @@ class GeoGraph:
             but Shapefiles also work.
 
         Returns:
-            STRtree: The Rtree object used to build the graph.
+            rtree_lib.index.Index: The Rtree object used to build the graph.
         """
         vector_df = polygonise(data_array=data_array, **raster_kwargs)
         if save_path is not None:
@@ -263,7 +270,7 @@ class GeoGraph:
             vector_df, attributes=["geometry", "class_label"], tolerance=self.tolerance
         )
 
-    def _load_from_graph_path(self, graph_path: pathlib.Path) -> STRtree:
+    def _load_from_graph_path(self, graph_path: pathlib.Path) -> rtree_lib.index.Index:
         """
         Load networkx graph and rtree objects from a pickle file.
 
@@ -272,7 +279,7 @@ class GeoGraph:
             with gzip or bz2.
 
         Returns:
-            STRtree: The Rtree object used to build the graph.
+            rtree_lib.index.Index: The Rtree object used to build the graph.
         """
         if graph_path.suffix == ".bz2":
             with bz2.BZ2File(graph_path, "rb") as bz2_file:
@@ -311,7 +318,7 @@ class GeoGraph:
         df: gpd.GeoDataFrame,
         attributes: Optional[List[str]] = None,
         tolerance: float = 0.0,
-    ) -> STRtree:
+    ) -> rtree_lib.index.Index:
         """
         Convert geopandas dataframe to networkx graph.
 
@@ -333,16 +340,16 @@ class GeoGraph:
             dataframe.
 
         Returns:
-            STRtree: The Rtree object used to build the graph.
+            rtree_lib.index.Index: The Rtree object used to build the graph.
         """
         if tolerance < 0.0:
             raise ValueError("`tolerance` must be greater than 0.")
-        if (
-            attributes is not None
-            and "class_label" not in attributes
-            or "class_label" not in df.columns
-        ):
-            raise ValueError("`class_label` must be a column in the dataframe.")
+        # if (
+        #    attributes is not None
+        #    and "class_label" not in attributes
+        #    or "class_label" not in df.columns
+        # ):
+        #    raise ValueError("`class_label` must be a column in the dataframe.")
         if (
             attributes is not None
             and "geometry" not in attributes
@@ -357,13 +364,10 @@ class GeoGraph:
             raise ValueError("`attributes` must only contain column names in `df`.")
 
         geom: Dict[int, shapely.Polygon] = df.geometry.to_dict()
-        # Build dict mapping hashable unique object ids for each polygon
-        # to their index in geom
-        id_dict: Dict[int, int] = {
-            id(polygon): index for index, polygon in geom.items()
-        }
         # Build Rtree from geometry
-        tree = STRtree(geom.values())
+        tree = rtree_lib.index.Index()
+        for index, polygon in geom.items():
+            tree.insert(index, polygon.bounds)
         # this dict maps polygon indices in df to a list
         # of neighbouring polygon indices
         graph_dict = {}
@@ -379,17 +383,15 @@ class GeoGraph:
                 new_polygon = polygon.buffer(tolerance)
                 # find the indexes of all polygons which intersect with this one
                 neighbours: List[int] = [
-                    id_dict[id(nbr)]
-                    for nbr in tree.query(new_polygon)
-                    if id_dict[id(nbr)] != id_dict[id(polygon)]
-                    and nbr.intersects(new_polygon)
+                    nbr_index
+                    for nbr_index in tree.intersection(new_polygon.bounds)
+                    if nbr_index != index and geom[nbr_index].intersects(new_polygon)
                 ]
             else:
                 neighbours = [
-                    id_dict[id(nbr)]
-                    for nbr in tree.query(polygon)
-                    if id_dict[id(nbr)] != id_dict[id(polygon)]
-                    and nbr.intersects(polygon)
+                    nbr_index
+                    for nbr_index in tree.intersection(polygon.bounds)
+                    if nbr_index != index and geom[nbr_index].intersects(polygon)
                 ]
             # this dict maps polygon indices in df to a list
             # of neighbouring polygon indices
@@ -467,3 +469,34 @@ class GeoGraph:
         self.graph.add_edges_from(
             zip_longest([final_index], adjacency_list, fillvalue=final_index)
         )
+
+    def add_habitat(
+        self,
+        name: str,
+        valid_classes: List[int],
+        max_travel_distance: float,
+        barrier_classes: List[int],
+    ):
+        """Add habitat graph to habitats dictionary."""
+        hgraph: nx.Graph = deepcopy(self.graph)
+        # Remove all edges in the graph, then at the end we only have edges
+        # between nodes less than `max_travel_distance` apart
+        hgraph.clear_edges()
+
+        for node in hgraph.nodes:
+            if hgraph.nodes[node]["class_label"] not in valid_classes:
+                continue
+
+            polygon = hgraph.nodes[node]["geometry"]
+            buff_poly = polygon.buffer(max_travel_distance)
+            poss_neighbours = list(self.rtree.intersection(buff_poly.bounds))
+            for nbr in poss_neighbours:
+                if hgraph.nodes[node]["class_label"] in barrier_classes:
+                    continue
+
+                nbr_polygon = hgraph.nodes[nbr]["geometry"]
+                if not hgraph.has_edge(node, nbr) and nbr_polygon.intersects(buff_poly):
+                    distance = polygon.distance(nbr_polygon)
+                    hgraph.add_edge(node, nbr, distance=distance)
+
+        self.habitats[name] = hgraph

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -344,12 +344,12 @@ class GeoGraph:
         """
         if tolerance < 0.0:
             raise ValueError("`tolerance` must be greater than 0.")
-        # if (
-        #    attributes is not None
-        #    and "class_label" not in attributes
-        #    or "class_label" not in df.columns
-        # ):
-        #    raise ValueError("`class_label` must be a column in the dataframe.")
+        if (
+            attributes is not None
+            and "class_label" not in attributes
+            or "class_label" not in df.columns
+        ):
+            raise ValueError("`class_label` must be a column in the dataframe.")
         if (
             attributes is not None
             and "geometry" not in attributes


### PR DESCRIPTION
This PR consists of the `add_habitat` function and the `get_graph_components` components function - closes #22, closes #27 

The `add_habitat` function takes in a name, a *set* of valid landcover classes, and a `max_travel_distance`, and adds an entry in the dictionary class attribute `habitats` with the resulting habitats graph. This graph is a subgraph of the main graph consisting of only the nodes with a `"class_label"` in the habitat, and edges between all nodes less than `max_travel_distance` apart.

The `get_graph_components` function takes in an `nx.Graph` object and returns a tuple of a `GeoDataFrame` and a `List[set]` containing the connected components of the graph. The List just contains sets containing the node indices of the nodes in each component, and the dataframe just contains one row for each component, with a single `"geometry"` column that stores the union polygon for the component. The caveat with this function is that the graph object passed must be a subgraph of the main class's graph, since it relies on the indices in the dataframe class attribute.

- Polygons are now stored in the dataframe, which is available as a class property along with the crs. The dataframe is now saved with the graph and rtree when saving to a pickle file.
- Switch to the `rtree` library, which has a much richer rtree implementation than Shapely's version.
- New node attributes: the `"class_label"` and `"bounds"` for each polygon. This is so that we can do `graph.nodes(data="bounds")` to iterate over all polygon bounds quickly. Other optional node attributes are no longer supported, since they are in the dataframe anyway which is now kept.
- Bugfixes in the `merge_nodes` function.