### PR TITLE
Feature/graph analysis metrics

### DIFF
--- a/src/models/binary_graph_operations.py
+++ b/src/models/binary_graph_operations.py
@@ -1,10 +1,17 @@
 """Contains tools for binary operations between GeoGraph objects."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from numpy import ndarray
 from src.models.polygon_utils import (
     connect_with_interior_bulk,
     connect_with_interior_or_edge_bulk,
     connect_with_interior_or_edge_or_corner_bulk,
 )
+
+if TYPE_CHECKING:
+    from src.models import geograph
 
 # For switching identifiction mode in `identify_node`
 _BULK_SPATIAL_IDENTIFICATION_FUNCTION = {
@@ -14,7 +21,9 @@ _BULK_SPATIAL_IDENTIFICATION_FUNCTION = {
 }
 
 
-def identify_node(node: dict, other_graph: "GeoGraph", mode: str = "corner") -> ndarray:
+def identify_node(
+    node: dict, other_graph: geograph.GeoGraph, mode: str = "corner"
+) -> ndarray:
     """
     Return list of all node ids in `other_graph` which identify with the given `node`.
 

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -7,24 +7,28 @@ from __future__ import annotations
 
 import bz2
 import gzip
+import inspect
 import os
 import pathlib
 import pickle
 from copy import deepcopy
-from dataclasses import dataclass
 from itertools import zip_longest
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import geopandas as gpd
 import networkx as nx
 import numpy as np
+import pandas as pd
 import pyproj
 import rasterio
 import shapely
 from shapely.prepared import prep
 from src.data_loading import rasterio_utils
-from src.models import binary_graph_operations
+from src.models import binary_graph_operations, metrics
+from src.models.metrics import Metric
 from tqdm import tqdm
+
+pd.options.mode.chained_assignment = None  # default='warn'
 
 VALID_EXTENSIONS = (
     ".pickle",
@@ -38,15 +42,6 @@ VALID_EXTENSIONS = (
     ".geotif",
     ".geotiff",
 )
-
-
-@dataclass
-class Habitat:
-    name: str
-    graph: nx.Graph
-    valid_classes: List[int]
-    max_travel_distance: float
-    add_distance: bool
 
 
 class GeoGraph:
@@ -118,10 +113,11 @@ class GeoGraph:
         """
         super().__init__()
         self.graph = nx.Graph()
-        self._habitats: Dict[str, Habitat] = {}
+        self.habitats: Dict[str, HabitatGeoGraph] = {}
         self._crs: Optional[Union[str, pyproj.CRS]] = crs
         self._columns_to_rename: Optional[Dict[str, str]] = columns_to_rename
         self._tolerance: float = tolerance
+        self.metrics: Dict[str, Metric] = {}
 
         if raster_save_path is not None:
             raster_save_path = pathlib.Path(raster_save_path)
@@ -168,28 +164,25 @@ class GeoGraph:
         # Save resulting graph, if we didn't load from graph.
         if not load_from_graph and graph_save_path is not None:
             graph_save_path = pathlib.Path(graph_save_path)
-            if graph_save_path.suffix not in (".pickle", ".pkl", ".gz", ".bz2"):
-                raise ValueError(
-                    """Argument `graph_save_path` should be a pickle file or
-                    compressed file."""
-                )
             os.makedirs(graph_save_path.parent, exist_ok=True)
-            self._save_graph(graph_save_path)
+            self.save_graph(graph_save_path)
+
+        self.components = self.get_graph_components(calc_polygons=False)
 
         print(
             f"Graph successfully loaded with {self.graph.number_of_nodes()} nodes",
             f"and {self.graph.number_of_edges()} edges.",
         )
 
+    def __eq__(self, o: object) -> bool:
+        if not isinstance(o, GeoGraph):
+            return False
+        return nx.is_isomorphic(self.graph, o.graph)
+
     @property
     def rtree(self):
         """Return Rtree object."""
         return self.df.sindex
-
-    @property
-    def habitats(self) -> Dict[str, Habitat]:
-        """Return habitat dictionary."""
-        return self._habitats
 
     @property
     def crs(self):
@@ -202,7 +195,7 @@ class GeoGraph:
 
         Note: Uses `iloc` type indexing.
         """
-        return self.df.class_label.values
+        return self.df["class_label"].values
 
     @property
     def geometry(self):
@@ -210,7 +203,7 @@ class GeoGraph:
 
         Note: Uses `iloc` type indexing.
         """
-        return self.df.geometry.values
+        return self.df["geometry"].values
 
     def _load_from_vector_path(
         self,
@@ -321,14 +314,22 @@ class GeoGraph:
         self.graph = data["graph"]
         return data["dataframe"]
 
-    def _save_graph(self, save_path: pathlib.Path) -> None:
+    def save_graph(self, save_path: pathlib.Path) -> None:
         """
         Save graph with attributes and dataframe as pickle file. Can be compressed.
 
         Args:
             save_path (pathlib.Path): Path to a pickle file. Can be compressed
             with gzip or bz2 by passing filenames ending in `gz` or `bz2`.
+
+        Raises:
+            ValueError: If `save_path` is not a pickle, gz, or bz2 file.
         """
+        if save_path.suffix not in (".pickle", ".pkl", ".gz", ".bz2"):
+            raise ValueError(
+                """Argument `save_path` should be a pickle file or
+                compressed file."""
+            )
         data = {"graph": self.graph, "dataframe": self.df}
         if save_path.suffix == ".bz2":
             with bz2.BZ2File(save_path, "wb") as bz2_file:
@@ -383,15 +384,16 @@ class GeoGraph:
         df = df.reset_index(drop=True)
         # Using this list and iterating through it is slightly faster than
         # iterating through df due to the dataframe overhead
-        geom: List[shapely.Polygon] = df.geometry.tolist()
-        class_labels: List[int] = df.class_label.tolist()
+        geom: List[shapely.Polygon] = df["geometry"].tolist()
         # this dict maps polygon row numbers in df to a list
         # of neighbouring polygon row numbers
         graph_dict = {}
 
         if tolerance > 0:
             # Expand the borders of the polygons by `tolerance```
-            new_polygons: List[shapely.Polygon] = df.geometry.buffer(tolerance).tolist()
+            new_polygons: List[shapely.Polygon] = (
+                df["geometry"].buffer(tolerance).tolist()
+            )
         # Creating nodes (=vertices) and finding neighbors
         for index, polygon in tqdm(
             enumerate(geom),
@@ -413,7 +415,6 @@ class GeoGraph:
                 rep_point=polygon.representative_point(),
                 area=polygon.area,
                 perimeter=polygon.length,
-                class_label=class_labels[index],
                 bounds=polygon.bounds,
             )
         # iterate through the dict and add edges between neighbouring polygons
@@ -429,7 +430,10 @@ class GeoGraph:
         return df
 
     def merge_nodes(
-        self, node_list: List[int], class_label: int, final_index: int = None
+        self,
+        node_list: List[int],
+        class_label: Union[int, str],
+        final_index: int = None,
     ) -> None:
         """
         Merge a list of nodes in the graph together into a single node.
@@ -439,19 +443,20 @@ class GeoGraph:
 
         Args:
             node_list (List[int]): List of integer node indexes in the graph.
-            class_label (int): Class label for the resulting node.
+            class_label (int or str): Class label for the resulting node.
             final_index (int, optional): Index to assign to the resulting node.
             Defaults to None, in which case it becomes the highest valid index
             in the dataframe + 1.
 
         Raises:
-            ValueError: If there are invalid nodes in `node_list`, or if
-            `final_index` is an existing node not in `node_list`.
+            ValueError: If `final_index` is an existing node not in `node_list`,
+            or if `node_list` does not contain any existing nodes.
         """
-        if not all(self.graph.has_node(node) for node in node_list):
-            raise ValueError("`node_list` must only contain valid nodes.")
+        node_list = [node for node in node_list if self.graph.has_node(node)]
+        if len(node_list) == 0:
+            raise ValueError("`node_list` must contain at least one node in the graph.")
         if final_index is None:
-            final_index = self.df.last_valid_index()
+            final_index = self.df.last_valid_index() + 1
         elif final_index not in node_list and self.graph.has_node(final_index):
             raise ValueError(
                 "`final_index` cannot be an existing node that is not in `node_list`."
@@ -464,7 +469,7 @@ class GeoGraph:
             adjacency_set.update(list(self.graph.neighbors(node)))
         adjacency_set -= adjacency_set.intersection(node_list)
         # Build union polygon.
-        polygon = self.df.geometry.loc[node_list].unary_union
+        polygon = self.df["geometry"].loc[node_list].unary_union
         # Remove nodes from graph and rows from df
         self.graph.remove_nodes_from(node_list)
         self.df = self.df.drop(node_list)
@@ -474,7 +479,6 @@ class GeoGraph:
             rep_point=polygon.representative_point(),
             area=polygon.area,
             perimeter=polygon.length,
-            class_label=class_label,
             bounds=polygon.bounds,
         )
         data = {"class_label": class_label, "geometry": polygon}
@@ -488,25 +492,48 @@ class GeoGraph:
             zip_longest([final_index], adjacency_set, fillvalue=final_index)
         )
 
+    def merge_classes(
+        self, class_list: List[Union[str, int]], new_name: Union[str, int]
+    ) -> None:
+        """
+        Merge multiple classes together into one by renaming the class labels.
+
+        Args:
+            new_name (Union[str, int]): The new name for the combined class,
+            either a string or an int.
+            class_list (List): The list of names of class labels to combine.
+            Every name in the list must be in the GeoGraph.
+
+        Raises:
+            ValueError: If `class_list` contains a class name not already in
+            the GeoGraph.
+        """
+        if not set(class_list).issubset(self.df["class_label"].unique()):
+            raise ValueError("`class_list` must only contain valid class names.")
+        self.df.loc[self.df["class_label"].isin(class_list), "class_label"] = new_name
+
     def add_habitat(
         self,
         name: str,
-        valid_classes: List[int],
+        valid_classes: List[Union[str, int]],
+        barrier_classes: Optional[List[Union[str, int]]] = None,
         max_travel_distance: float = 0.0,
         add_distance: bool = False,
+        add_component_edges: bool = False,
     ) -> None:
         """
-        Create habitat graph and store it in habitats dictionary.
+        Create HabitatGeoGraph object and store it in habitats dictionary.
 
         Creates a habitat subgraph of the main GeoGraph that only contains edges
         between nodes in `valid_classes` as long as they are less than
         `max_travel_distance` apart. All nodes which are not in `valid_classes`
-        are not in the resulting habitat graph.
+        are not in the resulting habitat graph. This graph is then stored as its
+        own HabitatGeoGraph object with all meta information.
 
         Args:
             name (str): The name of the habitat.
-            valid_classes (List[int]): A list of integer class labels which make
-            up the habitat.
+            valid_classes (List): A list of class labels which make up the habitat.
+            barrier_classes (List): Defaults to None.
             max_travel_distance (float): The maximum distance the animal(s) in
             the habitat can travel through non-habitat areas. The habitat graph
             will contain edges between any two nodes that have a class label in
@@ -514,13 +541,21 @@ class GeoGraph:
             units apart. Defaults to 0, which will only create edges between
             directly neighbouring areas.
             add_distance (bool, optional): Whether or not to add the distance
-            between polygons as an edge attribute. Defaults to False.
+            between polygons as an edge attribute in the habitat graph. Defaults
+            to False.
+            add_component_edges (bool, optional): Whether to add edges between
+            nodes in the ComponentGeoGraph (which is automatically created as an
+            attribute of the resulting HabitatGeoGraph) with edge weights that
+            are the distance between neighbouring components. Can be
+            computationally expensive. Defaults to False.
 
         Raises:
             ValueError: If max_travel_distance < 0.
         """
-        if max_travel_distance < 0:
+        if max_travel_distance < 0.0:
             raise ValueError("`max_travel_distance` must be greater than 0.")
+        if barrier_classes is None:
+            barrier_classes = []
         hgraph: nx.Graph = deepcopy(self.graph)
         # Remove all edges in the graph, then at the end we only have edges
         # between nodes less than `max_travel_distance` apart
@@ -530,21 +565,17 @@ class GeoGraph:
         idx_dict: Dict[int, int] = dict(zip(range(len(self.df)), self.df.index.values))
         # Get dicts of polygons and buff polygons to avoid repeatedly querying
         # the dataframe. These dicts accept loc indexes
-        polygons: Dict[int, shapely.Polygon] = self.df.geometry.to_dict()
+        polygons: Dict[int, shapely.Polygon] = self.df["geometry"].to_dict()
         if max_travel_distance > 0:
             # Vectorised buffer on the entire df to calculate the expanded polygons
             # used to get intersections.
-            buff_polygons = self.df.geometry.buffer(max_travel_distance).to_dict()
+            buff_polygons = self.df["geometry"].buffer(max_travel_distance).to_dict()
         # Remove non-habitat nodes from habitat graph
         # np.where is very fast here and gets the iloc based indexes
         # Combining it with the set comprehension reduces time by an order of
-        # magnitude compared to `set(self.df.loc()`
-        invalid_idx = {
-            idx_dict[i]
-            for i in np.where(~self.df["class_label"].isin(set(valid_classes)).values)[
-                0
-            ]
-        }
+        # magnitude compared to `set(self.df.loc[])`
+        valid_class_indices = np.isin(self.class_label, valid_classes)
+        invalid_idx = {idx_dict[i] for i in np.where(~valid_class_indices)[0]}
         hgraph.remove_nodes_from(invalid_idx)
 
         for node in tqdm(
@@ -576,36 +607,60 @@ class GeoGraph:
                     else:
                         hgraph.add_edge(node, nbr)
         # Add habitat to habitats dict
-        habitat = Habitat(
+        habitat = HabitatGeoGraph(
+            data=self.df.iloc[np.where(valid_class_indices)[0]],
             name=name,
             graph=hgraph,
             valid_classes=valid_classes,
+            barrier_classes=barrier_classes,
             max_travel_distance=max_travel_distance,
             add_distance=add_distance,
+            add_component_edges=add_component_edges,
         )
-        self._habitats[name] = habitat
+        self.habitats[name] = habitat
 
-        print(
-            f"Habitat successfully loaded with {hgraph.number_of_nodes()} nodes",
-            f"and {hgraph.number_of_edges()} edges.",
-        )
+    def apply_to_habitats(self, func: Callable, **kwargs) -> List[Any]:
+        """
+        Apply a function to all habitats in this GeoGraph.
+
+        The function must be a method of GeoGraph or HabitatGeoGraph. **kwargs
+        are applied to the function - all passed arguments must be specified
+        with the keyword.
+
+        Args:
+            func (Callable): A function that is a method of GeoGraph or
+            HabitatGeoGraph. This must not be a method of an instance of
+            GeoGraph; it can only be an actual method definition, such as
+            `GeoGraph.merge_nodes`.
+
+        Raises:
+            ValueError: If `func` is not a method of GeoGraph or HabitatGeoGraph.
+
+        Returns:
+            List[Any]: A list of the returned results.
+        """
+        # __qualname__ should be something like "GeoGraph.merge_nodes"
+        if (
+            not func.__qualname__.split(".")[0] in ("GeoGraph", "HabitatGeoGraph")
+            or "self" not in inspect.signature(func).parameters
+        ):
+            raise ValueError("`func` is not a method of GeoGraph or HabitatGeoGraph.")
+        return [func(self=habitat, **kwargs) for habitat in self.habitats.values()]
 
     def get_graph_components(
-        self, graph: nx.Graph
-    ) -> Tuple[gpd.GeoDataFrame, List[set]]:
-        """Return a GeoDataFrame with graph components.
+        self, calc_polygons: bool = True, add_distance_edges: bool = False
+    ) -> ComponentGeoGraph:
+        """Return a GeoGraph with the connected components of this graph.
 
-        This method takes an nx.Graph and determines the individual disconnected
-        graph components that make up the graph. Each row of the returned
-        GeoDataFrame corresponds to a graph component, with entries in column
-        'geometry' being the union of all individual polygons making up a
-        component.
+        This method determines the individual disconnected graph components that
+        make up the graph of the GeoGraph object. It returns a ComponentGeoGraph
+        object such that each row of the GeoDataFrame and each node in the
+        networkx.Graph correspond to a connected component in the main graph,
+        and the polygons in the dataframe are the union of all individual
+        polygons making up a component in the main graph.
 
-        Warning: this method can only be passed graphs which are a subgraph of
-        this class's main `graph` attribute, such as the habitat subgraph or the
-        main graph itself. Warning: this method is very slow if the graph
-        consists mostly of one big component, because taking the union is
-        expensive.
+        Warning: this method is very slow if `calc_polygons=True` and the graph
+        consists mostly of one big component, since taking the union is expensive.
 
         This method allows for the UI to visualise components and output their
         number as a metric.
@@ -614,21 +669,317 @@ class GeoGraph:
         https://en.wikipedia.org/wiki/Component_(graph_theory)
 
         Args:
-            graph (nx.Graph): nx.Graph object. This must be a subgraph of this
-            class's main `graph` attribute.
+            calc_polygons (bool, optional): This determines whether to calculate
+            the polygons which are the union of all the polygons that make up
+            each component, and load a `ComponentGeoGraph` with a corresponding
+            dataframe containing these components. This can be time consuming
+            if there is a very large component. Defaults to True.
+            add_distance_edges (bool, optional): This determines whether to add
+            edges between every pair of nodes, with the distance between their
+            corresponding polygons as an edge attribute. Defaults to False.
 
         Returns:
-            Tuple: A tuple containing the resulting GeoDataFrame and the list of
-            graph components.
+            ComponentGeoGraph: A ComponentGeoGraph containing the resulting
+            GeoDataFrame (if `calc_polygons=True`) and the list of graph
+            components.
         """
-        components: List[set] = list(nx.connected_components(graph))
-        geom = [self.df.geometry.loc[comp].unary_union for comp in components]
-        gdf = gpd.GeoDataFrame({"geometry": geom}, crs=self.df.crs)
-        return gdf, components
+        components: List[set] = list(nx.connected_components(self.graph))
+        if calc_polygons:
+            geom = [self.df["geometry"].loc[comp].unary_union for comp in components]
+            gdf = gpd.GeoDataFrame(
+                {"geometry": geom, "class_label": -1}, crs=self.df.crs
+            )
+            comp_geograph = ComponentGeoGraph(
+                components, gdf, add_distance_edges=add_distance_edges
+            )
+        else:
+            comp_geograph = ComponentGeoGraph(components)
+        if not hasattr(self, "components"):
+            self.components = comp_geograph
+        return comp_geograph
+
+    def get_metric(self, name: str) -> metrics.Metric:
+        """
+        Calculate and save the metric with name `name` for the current GeoGraph.
+
+        Args:
+            name (str): The name of a valid metric for a GeoGraph.
+
+        Returns:
+            metrics.Metric: The Metric object, containing the value as well as
+            other information about the metric.
+        """
+        if name not in metrics.METRICS_DICT:
+            raise ValueError("`name` must be the name of a valid metric.")
+        try:
+            result = self.metrics[name]
+        except KeyError:
+            # pylint: disable=protected-access
+            result = metrics._get_metric(name=name, geo_graph=self)
+            self.metrics[name] = result
+        return result
 
     def identify_node(
         self, node_id: int, other_graph: GeoGraph, mode: str
     ) -> List[int]:
+        """Return all node ids in `other_graph` which identify with `node_id`."""
         return binary_graph_operations.identify_node(
             self.df.loc[node_id], other_graph=other_graph, mode=mode
         ).tolist()
+
+
+class HabitatGeoGraph(GeoGraph):
+    """Class to represent a habitat GeoGraph."""
+
+    def __init__(
+        self,
+        data: Union[gpd.GeoDataFrame, str, os.PathLike],
+        name: Optional[str] = None,
+        graph: Optional[nx.Graph] = None,
+        valid_classes: Optional[List[Union[str, int]]] = None,
+        barrier_classes: Optional[List[Union[str, int]]] = None,
+        max_travel_distance: Optional[float] = 0,
+        add_distance: bool = False,
+        add_component_edges: bool = False,
+    ) -> None:
+        """
+        Class to represent a habitat GeoGraph.
+
+        This class can load a habitat GeoGraph from a GeoDataFrame and networkx
+        graph object, or alternatively load saved pickle or compressed pickle
+        file with the graph, dataframe, and all metadata. Valid saved file formats
+        are .pickle, .pkl, .gz, or .bz2.
+
+        Args:
+            data: (GeoDataFrame or Path): Either a dataframe with the polygon
+            data for the habitat graph nodes, or a path to a saved habitat. If
+            it is a GeoDataFrame, then the other arguments in this init are
+            mandatory (except for `add_distance` and `add_component_edges`)
+            name (str, optional): The name of the habitat.
+            graph (nx.Graph, optional): A networkx graph representing the habitat.
+            Defaults to None.
+            valid_classes (List, optional): A list of class labels which make up
+            the habitat.
+            barrier_classes (List, optional): A list of barrier class labels.
+            max_travel_distance (float, optional): The maximum distance the
+            animal(s) in the habitat can travel through non-habitat areas. The
+            habitat graph will contain edges between any two nodes that have a
+            class label in `valid_classes`, as long as they are less than
+            `max_travel_distance` units apart.
+            add_distance (bool, optional): Whether or not to add the distance
+            between polygons has been added as an edge attribute in `graph`.
+            add_component_edges (bool, optional): Whether to add edges between
+            nodes in the ComponentGeoGraph created automatically for this
+            habitatwith edge weights that are the distance between neighbouring
+            components. Can be computationally expensive. Defaults to False.
+
+        Raises:
+            ValueError: If `data` is of an unknown type, or if `data` is a file
+            path of an invalid suffix.
+        """
+        # pylint: disable=super-init-not-called
+        if isinstance(data, gpd.GeoDataFrame):
+            # Note that index is not reset, so it contains the loc indices of the
+            # same patches in the main df
+            self.df: gpd.GeoDataFrame = data
+            if (
+                name is not None
+                and graph is not None
+                and valid_classes is not None
+                and barrier_classes is not None
+                and max_travel_distance is not None
+            ):
+                self.name: str = name
+                self.graph: nx.Graph = graph
+                self.valid_classes: List[Union[str, int]] = valid_classes
+                self.barrier_classes: List[Union[str, int]] = barrier_classes
+                self.max_travel_distance: float = max_travel_distance
+                self.add_distance: bool = add_distance
+        elif isinstance(data, (str, os.PathLike)):
+            load_path = pathlib.Path(data)
+            assert load_path.exists()
+            # Load from saved graph
+            if load_path.suffix in (".pickle", ".pkl", ".gz", ".bz2"):
+                self._load_from_graph_path(load_path)
+            else:
+                raise ValueError(
+                    f"""Extension {load_path.suffix} unknown.
+                                 Must be one of .pickle, .pkl, .gz, .bz2."""
+                )
+        else:
+            raise ValueError(
+                """Type of `data` unknown. Must be a dataframe or file path."""
+            )
+        print("Calculating components...")
+        self.components = self.get_graph_components(
+            calc_polygons=True, add_distance_edges=add_component_edges
+        )
+        self.metrics: Dict[str, Metric] = {}
+        print(
+            f"Habitat successfully loaded with {self.graph.number_of_nodes()} nodes",
+            f"and {self.graph.number_of_edges()} edges.",
+        )
+
+    def _load_from_graph_path(self, load_path: pathlib.Path) -> None:
+        """
+        Load networkx graph and dataframe objects from a pickle file.
+
+        Args:
+            load_path (pathlib.Path): Path to a pickle file. Can be compressed
+            with gzip or bz2.
+
+        Returns:
+            gpd.GeoDataFrame: The dataframe containing polygon objects.
+        """
+        if load_path.suffix == ".bz2":
+            with bz2.BZ2File(load_path, "rb") as bz2_file:
+                data = pickle.load(bz2_file)
+        elif load_path.suffix == ".gz":
+            with gzip.GzipFile(load_path, "rb") as gz_file:
+                data = pickle.loads(gz_file.read())
+        else:
+            with open(load_path, "rb") as file:
+                data = pickle.load(file)
+        self.df = data["dataframe"]
+        self.name = data["name"]
+        self.valid_classes = data["valid_classes"]
+        self.barrier_classes = data["barrier_classes"]
+        self.max_travel_distance = data["max_travel_distance"]
+        self.add_distance = data["add_distance"]
+
+    def save_habitat(self, save_path: pathlib.Path) -> None:
+        """
+        Save graph with attributes and dataframe as pickle file. Can be compressed.
+
+        Args:
+            save_path (pathlib.Path): Path to a pickle file. Can be compressed
+            with gzip or bz2 by passing filenames ending in `gz` or `bz2`.
+
+        Raises:
+            ValueError: If `save_path` is not a pickle, gz, or bz2 file.
+        """
+        if save_path.suffix not in (".pickle", ".pkl", ".gz", ".bz2"):
+            raise ValueError(
+                """Argument `save_path` should be a pickle file or
+                compressed file."""
+            )
+        data = {
+            "graph": self.graph,
+            "dataframe": self.df,
+            "name": self.name,
+            "valid_classes": self.valid_classes,
+            "barrier_classes": self.barrier_classes,
+            "max_travel_distance": self.max_travel_distance,
+            "add_distance": self.add_distance,
+        }
+        if save_path.suffix == ".bz2":
+            with bz2.BZ2File(save_path, "wb") as bz2_file:
+                pickle.dump(data, bz2_file)
+        elif save_path.suffix == ".gz":
+            with gzip.GzipFile(save_path, "wb") as gz_file:
+                gz_file.write(pickle.dumps(data))
+        else:
+            with open(save_path, "wb") as file:
+                pickle.dump(data, file)
+        save_path.chmod(0o664)
+
+
+class ComponentGeoGraph(GeoGraph):
+    """Class to represent the connected components of a GeoGraph."""
+
+    def __init__(
+        self,
+        components_list: List[set],
+        df: Optional[gpd.GeoDataFrame] = None,
+        add_distance_edges: bool = False,
+    ) -> None:
+        """
+        Class for the connected components of a GeoGraph.
+
+        This class can load a graph from only a list of components, in which
+        case it will not have a dataframe and the `has_df` class attribute will
+        be False, or it can load from both a list of components and a dataframe.
+        In the latter case, edges with the polygon distance can be added between
+        each pair of nodes (where each node corresponds to a connected component
+        in the original graph).
+
+        WARNING: using `add_distance_edges=True` is incredibly slow for anything
+        other than the smallest habitats.
+
+        Args:
+            components_list (List[set]): A list of sets, where each set contains
+            the node indices making up a component from the original graph.
+            df (Optional[gpd.GeoDataFrame], optional): A GeoDataFrame in which
+            each row contains a polygon that represents a component from a
+            GeoGraph. This is optional, and if not passed the graph will be
+            created with no edges. Defaults to None.
+            add_distance_edges (bool, optional): Boolean that determines whether
+            to add edges between every pair of nodes, with the distance between
+            their corresponding polygons as an edge attribute. Defaults to False.
+        """
+        # pylint: disable=super-init-not-called
+        self.has_df: bool = True
+        self.graph: nx.Graph = nx.Graph()
+        self.components_list: List[set] = components_list
+        if df is not None:
+            self.has_distance_edges: bool = add_distance_edges
+            self.df = self._load_from_dataframe(df, add_distance_edges)
+        else:
+            self.has_df = False
+            self.has_distance_edges = False
+            self.graph = nx.empty_graph(len(self.components_list))
+        self.metrics: Dict[str, Metric] = {}
+
+    def _load_from_dataframe(
+        self,
+        df: gpd.GeoDataFrame,
+        tolerance: float = 0.0,
+    ) -> gpd.GeoDataFrame:
+        """
+        Load graph from dataframe.
+
+        If `self.has_distance_edges` is True, then this will load a complete graph
+        and add the distance between each pair of polygons as an edge attribute.
+        Otherwise, it will load an empty graph.
+
+        In both cases, information about the polygons will be stored as node
+        attributes.
+
+        Args:
+            df (gpd.GeoDataFrame): GeoDataFrame containing polygon objects.
+            tolerance (float, optional): Redundant argument to ensure interface
+            is consistent with parent class. Defaults to 0.0.
+
+        Returns:
+            gpd.GeoDataFrame: A processed GeoDataFrame containing polygon objects.
+        """
+        # Reset index to ensure consistent indices
+        df = df.reset_index(drop=True)
+        # Using this list and iterating through it is slightly faster than
+        # iterating through df due to the dataframe overhead
+        geom: List[shapely.Polygon] = df["geometry"].tolist()
+        if self.has_distance_edges:
+            self.graph = nx.complete_graph(len(df))
+        else:
+            self.graph = nx.empty_graph(len(df))
+        # Add node attributes
+        for node in tqdm(
+            self.graph.nodes, desc="Constructing graph", total=len(self.graph)
+        ):
+            polygon = geom[node]
+            self.graph.nodes[node]["rep_point"] = polygon.representative_point()
+            self.graph.nodes[node]["area"] = polygon.area
+            self.graph.nodes[node]["perimeter"] = polygon.length
+            self.graph.nodes[node]["bounds"] = polygon.bounds
+
+        # Add edge attributes if necessary
+        if self.has_distance_edges:
+            for u, v, attrs in tqdm(
+                self.graph.edges.data(data=True),
+                desc="Calculating edge weights",
+                total=len(self.graph.edges),
+            ):
+                attrs["distance"] = geom[u].distance(geom[v])
+        # add index name
+        df.index.name = "node_index"
+        return df

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -464,7 +464,7 @@ class GeoGraph:
             adjacency_set.update(list(self.graph.neighbors(node)))
         adjacency_set -= adjacency_set.intersection(node_list)
         # Build union polygon.
-        polygon = self.df.geometry.iloc[node_list].unary_union
+        polygon = self.df.geometry.loc[node_list].unary_union
         # Remove nodes from graph and rows from df
         self.graph.remove_nodes_from(node_list)
         self.df = self.df.drop(node_list)

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -923,7 +923,7 @@ class ComponentGeoGraph(GeoGraph):
         self.components_list: List[set] = components_list
         if df is not None:
             self.has_distance_edges: bool = add_distance_edges
-            self.df = self._load_from_dataframe(df, add_distance_edges)
+            self.df = self._load_from_dataframe(df)
         else:
             self.has_df = False
             self.has_distance_edges = False

--- a/src/models/geograph.py
+++ b/src/models/geograph.py
@@ -177,7 +177,7 @@ class GeoGraph:
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, GeoGraph):
             return False
-        return nx.is_isomorphic(self.graph, o.graph)
+        return nx.fast_could_be_isomorphic(self.graph, o.graph)
 
     @property
     def rtree(self):

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -1,0 +1,115 @@
+"""Functions for calculating metrics from a GeoGraph."""
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+import networkx as nx
+import numpy as np
+import shapely
+from src.models import geograph
+
+
+@dataclass
+class Metric:
+    name: str
+    description: str
+    value: Any  # No good Numpy type hints
+    variant: Optional[str]
+    unit: Optional[str] = None
+
+
+def _get_num_components(geo_graph: geograph.GeoGraph) -> Metric:
+    components: List[set] = list(nx.connected_components(geo_graph.graph))
+    return Metric(
+        name="num_components",
+        description="The number of connected components in the graph.",
+        value=len(components),
+        variant="component",
+    )
+
+
+def _get_avg_patch_area(geo_graph: geograph.GeoGraph) -> Metric:
+    return Metric(
+        name="avg_patch_area",
+        description="The average area of the patches in the graph.",
+        value=np.mean(geo_graph.df.area.values),
+        variant="conventional",
+    )
+
+
+def _get_total_area(geo_graph: geograph.GeoGraph) -> Metric:
+    return Metric(
+        name="total_area",
+        description="The total area of all the patches in the graph.",
+        value=np.sum(geo_graph.df.area.values),
+        variant="conventional",
+    )
+
+
+def _get_avg_component_area(geo_graph: geograph.GeoGraph) -> Metric:
+    components_gdf, _ = geo_graph.get_graph_components(geo_graph.graph)
+    return Metric(
+        name="avg_component_area",
+        description="The average area of the components in the graph",
+        value=np.mean(components_gdf.area.values),
+        variant="component",
+    )
+
+
+def _get_avg_component_isolation(geo_graph: geograph.GeoGraph) -> Metric:
+    """Return the average distance to the next-nearest component."""
+    components_gdf, _ = geo_graph.get_graph_components(geo_graph.graph)
+    comp_graph = nx.Graph()
+
+    geom: List[shapely.Polygon] = components_gdf.geometry.values
+    graph_dict = {}
+
+    # Creating nodes (=vertices) and finding neighbors
+    for index, polygon in enumerate(geom):
+        neighbours = components_gdf.sindex.query(polygon, predicate="intersects")
+
+        graph_dict[index] = neighbours
+        # add each component as a node to the graph with useful attributes
+        comp_graph.add_node(
+            index,
+            rep_point=polygon.representative_point(),
+            area=polygon.area,
+            perimeter=polygon.length,
+            bounds=polygon.bounds,
+            geometry=polygon,
+        )
+    # iterate through the dict and add edges between neighbouring components
+    for polygon_id, neighbours in graph_dict.items():
+        for neighbour_id in neighbours:
+            if polygon_id != neighbour_id:
+                comp_graph.add_edge(polygon_id, neighbour_id)
+
+    dist_set = set()
+    for comp in comp_graph.nodes:
+        for neighbour in comp_graph.adj[comp]:
+            polygon = comp.geometry
+            dist_set.update(
+                [polygon.distance(nbr.geometry) for nbr in comp_graph.adj[neighbour]]
+            )
+    mean_patch_isolation = np.mean(np.fromiter(dist_set, np.float32, len(dist_set)))
+    return Metric(
+        name="avg_component_isolation",
+        description="The average distance to the next-nearest component",
+        value=mean_patch_isolation,
+        variant="component",
+    )
+
+
+METRICS_DICT = {
+    "num_components": _get_num_components,
+    "avg_patch_area": _get_avg_patch_area,
+    "total_area": _get_total_area,
+    "avg_component_area": _get_avg_component_area,
+    "avg_component_isolation": _get_avg_component_isolation,
+}
+
+
+def get_metric(name: str, geo_graph: geograph.GeoGraph) -> Metric:
+    try:
+        return METRICS_DICT[name](geo_graph)
+    except KeyError as key_error:
+        raise ValueError("Argument `name` is not a valid metric") from key_error

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -1,116 +1,136 @@
 """Functions for calculating metrics from a GeoGraph."""
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import networkx as nx
 import numpy as np
-import shapely
-from src.models import geograph
+
+if TYPE_CHECKING:
+    from src.models import geograph
 
 
-# define a metric dataclass with order = true, which means that
-# two different Metrics will obey with < <= => > == comparisons
-# as you would expect intuitively
-@dataclass(order=True)
+# define a metric dataclass with < <= => > == comparisons that work as you would
+# expect intuitively
+@dataclass()
 class Metric:
+    """Class to represent a metric for a GeoGraph, with associated metadata."""
+
     value: Any  # No good Numpy type hints
     name: str
     description: str
     variant: Optional[str]
     unit: Optional[str] = None
 
+    def __eq__(self, o: object) -> bool:
+        if not isinstance(o, Metric):
+            return False
+        return self.value == o.value
 
-def _get_num_components(geo_graph: geograph.GeoGraph) -> Metric:
+    def __lt__(self, o: object) -> bool:
+        if not isinstance(o, Metric):
+            return False
+        return self.value < o.value
+
+    def __le__(self, o: object) -> bool:
+        if not isinstance(o, Metric):
+            return False
+        return self.value <= o.value
+
+    def __gt__(self, o: object) -> bool:
+        if not isinstance(o, Metric):
+            return False
+        return self.value > o.value
+
+    def __ge__(self, o: object) -> bool:
+        if not isinstance(o, Metric):
+            return False
+        return self.value >= o.value
+
+
+def _num_components(geo_graph: geograph.GeoGraph) -> Metric:
     return Metric(
+        value=nx.number_connected_components(geo_graph.graph),
         name="num_components",
         description="The number of connected components in the graph.",
-        value=nx.number_connected_components(geo_graph.graph),
         variant="component",
     )
 
 
-def _get_avg_patch_area(geo_graph: geograph.GeoGraph) -> Metric:
+def _avg_patch_area(geo_graph: geograph.GeoGraph) -> Metric:
     return Metric(
+        value=np.mean(geo_graph.df.area.values),
         name="avg_patch_area",
         description="The average area of the patches in the graph.",
-        value=np.mean(geo_graph.df.area.values),
         variant="conventional",
     )
 
 
-def _get_total_area(geo_graph: geograph.GeoGraph) -> Metric:
+def _total_area(geo_graph: geograph.GeoGraph) -> Metric:
     return Metric(
+        value=np.sum(geo_graph.df.area.values),
         name="total_area",
         description="The total area of all the patches in the graph.",
-        value=np.sum(geo_graph.df.area.values),
         variant="conventional",
     )
 
 
-def _get_avg_component_area(geo_graph: geograph.GeoGraph) -> Metric:
-    components_gdf, _ = geo_graph.get_graph_components(geo_graph.graph)
+def _avg_component_area(geo_graph: geograph.GeoGraph) -> Metric:
+    comp_geograph = geo_graph.components
+    if not comp_geograph.has_df:
+        raise ValueError(
+            "This metric is not valid for ComponentGeoGraphs without a dataframe."
+        )
     return Metric(
+        value=np.mean(comp_geograph.df.area.values),
         name="avg_component_area",
         description="The average area of the components in the graph",
-        value=np.mean(components_gdf.area.values),
         variant="component",
     )
 
 
-def _get_avg_component_isolation(geo_graph: geograph.GeoGraph) -> Metric:
-    """Return the average distance to the next-nearest component."""
-    components_gdf, _ = geo_graph.get_graph_components(geo_graph.graph)
-    comp_graph = nx.Graph()
-
-    geom: List[shapely.Polygon] = components_gdf.geometry.tolist()
-    graph_dict = {}
-
-    # Creating nodes (=vertices) and finding neighbors
-    for index, polygon in enumerate(geom):
-        neighbours = components_gdf.sindex.query(polygon, predicate="intersects")
-
-        graph_dict[index] = neighbours
-        # add each component as a node to the graph with useful attributes
-        comp_graph.add_node(
-            index,
-            rep_point=polygon.representative_point(),
-            area=polygon.area,
-            perimeter=polygon.length,
-            bounds=polygon.bounds,
-            geometry=polygon,
+def _avg_component_isolation(geo_graph: geograph.GeoGraph) -> Metric:
+    """Calculate the average distance to the next-nearest component."""
+    comp_geograph = geo_graph.components
+    if not comp_geograph.has_df:
+        raise ValueError(
+            "This metric is not valid for ComponentGeoGraphs without a dataframe."
         )
-    # iterate through the dict and add edges between neighbouring components
-    for polygon_id, neighbours in graph_dict.items():
-        for neighbour_id in neighbours:
-            if polygon_id != neighbour_id:
-                comp_graph.add_edge(polygon_id, neighbour_id)
+    elif not comp_geograph.has_distance_edges:
+        raise ValueError(
+            "This metric is not valid for ComponentGeoGraphs without distance edges."
+        )
 
     dist_set = set()
-    for comp in comp_graph.nodes:
-        for neighbour in comp_graph.adj[comp]:
-            polygon = comp.geometry
+    for comp in comp_geograph.graph.nodes:
+        for nbr in comp_geograph.graph.adj[comp]:
             dist_set.update(
-                [polygon.distance(nbr.geometry) for nbr in comp_graph.adj[neighbour]]
+                [
+                    dist
+                    for u, v, dist in comp_geograph.graph.edges(nbr, data="distance")
+                    if v != comp
+                ]
             )
     mean_patch_isolation = np.mean(np.fromiter(dist_set, np.float32, len(dist_set)))
     return Metric(
+        value=mean_patch_isolation,
         name="avg_component_isolation",
         description="The average distance to the next-nearest component",
-        value=mean_patch_isolation,
         variant="component",
     )
 
 
 METRICS_DICT = {
-    "num_components": _get_num_components,
-    "avg_patch_area": _get_avg_patch_area,
-    "total_area": _get_total_area,
-    "avg_component_area": _get_avg_component_area,
-    "avg_component_isolation": _get_avg_component_isolation,
+    "num_components": _num_components,
+    "avg_patch_area": _avg_patch_area,
+    "total_area": _total_area,
+    "avg_component_area": _avg_component_area,
+    "avg_component_isolation": _avg_component_isolation,
 }
 
 
-def get_metric(name: str, geo_graph: geograph.GeoGraph) -> Metric:
+def _get_metric(name: str, geo_graph: geograph.GeoGraph) -> Metric:
     try:
         return METRICS_DICT[name](geo_graph)
     except KeyError as key_error:

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -101,20 +101,24 @@ def _avg_component_isolation(geo_graph: geograph.GeoGraph) -> Metric:
         raise ValueError(
             "This metric is not valid for ComponentGeoGraphs without distance edges."
         )
-
-    dist_set = set()
-    for comp in comp_geograph.graph.nodes:
-        for nbr in comp_geograph.graph.adj[comp]:
-            dist_set.update(
-                [
-                    dist
-                    for u, v, dist in comp_geograph.graph.edges(nbr, data="distance")
-                    if v != comp
-                ]
-            )
-    mean_patch_isolation = np.mean(np.fromiter(dist_set, np.float32, len(dist_set)))
+    if len(comp_geograph.components_list) == 1:
+        val: Any = 0
+    else:
+        dist_set = set()
+        for comp in comp_geograph.graph.nodes:
+            for nbr in comp_geograph.graph.adj[comp]:
+                dist_set.update(
+                    [
+                        dist
+                        for u, v, dist in comp_geograph.graph.edges(
+                            nbr, data="distance"
+                        )
+                        if v != comp
+                    ]
+                )
+        val = np.mean(np.fromiter(dist_set, np.float32, len(dist_set)))
     return Metric(
-        value=mean_patch_isolation,
+        value=val,
         name="avg_component_isolation",
         description="The average distance to the next-nearest component",
         variant="component",

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -60,7 +60,7 @@ def _get_avg_component_isolation(geo_graph: geograph.GeoGraph) -> Metric:
     components_gdf, _ = geo_graph.get_graph_components(geo_graph.graph)
     comp_graph = nx.Graph()
 
-    geom: List[shapely.Polygon] = components_gdf.geometry.values
+    geom: List[shapely.Polygon] = components_gdf.geometry.tolist()
     graph_dict = {}
 
     # Creating nodes (=vertices) and finding neighbors

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -8,11 +8,14 @@ import shapely
 from src.models import geograph
 
 
-@dataclass
+# define a metric dataclass with order = true, which means that
+# two different Metrics with the same `name` will work with < <= => > ==
+# comparisons as you would expect intuitively
+@dataclass(order=True)
 class Metric:
     name: str
-    description: str
     value: Any  # No good Numpy type hints
+    description: str
     variant: Optional[str]
     unit: Optional[str] = None
 

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -9,12 +9,12 @@ from src.models import geograph
 
 
 # define a metric dataclass with order = true, which means that
-# two different Metrics with the same `name` will work with < <= => > ==
-# comparisons as you would expect intuitively
+# two different Metrics will obey with < <= => > == comparisons
+# as you would expect intuitively
 @dataclass(order=True)
 class Metric:
-    name: str
     value: Any  # No good Numpy type hints
+    name: str
     description: str
     variant: Optional[str]
     unit: Optional[str] = None

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -18,11 +18,10 @@ class Metric:
 
 
 def _get_num_components(geo_graph: geograph.GeoGraph) -> Metric:
-    components: List[set] = list(nx.connected_components(geo_graph.graph))
     return Metric(
         name="num_components",
         description="The number of connected components in the graph.",
-        value=len(components),
+        value=nx.number_connected_components(geo_graph.graph),
         variant="component",
     )
 


### PR DESCRIPTION
This PR adds metrics to GeoGraph by defining a Metric dataclass. A Metric object is then returned when a metric is calculated; each metric calculation function accepts only a GeoGraph, so that you can calculate any metric by calling the `get_metric` method on any GeoGraph and passing only the name of the metric. The PR also changes Habitats and Components to be sub-classes of GeoGraph, so you can now have recursively nested HabitatGeoGraphs, each with a ComponentGeoGraph, and you can calculate metrics on all of them!

Other features:

- A `merge_classes` function which can be used to avoid some extra lines when combining class labels in the dataframe.
- Tested support for string class labels as well as integer ones.
- An `apply_to_habitats` function which allows you to apply a GeoGraph method, like `merge_nodes`, to every HabitatGeoGraph attached to a GeoGraph in one go, assuming each application uses the same arguments.
- Further speedup in `add_habitat`.
- Improved `get_graph_components` function, which now supports optionally calculating the union polygons for each component (by default this is not done for a GeoGraph, but is done for a HabitatGeoGraph since habitats are often small enough that this is fairly cheap).
- Habitat-specific saving and loading.
- Implemented \_\_eq\_\_ for GeoGraphs which checks if the two GeoGraphs are isomorphic.
- Similarly, you can compare Metric objects with < <= == >= > and they will work as you would expect by comparing the underlying values.
- ComponentGeoGraphs support optionally adding an edge between every pair of nodes (each node represents a component in the original graph) with the distance between the node polygons as an edge attribute. This is very slow for any habitat with more than about 100 components, so is disabled by default, but it is necessary for the `avg_component_isolation` metric.