### PR TITLE
docs: add doc build status shield to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ _Created as part of the AI4ER Group Team Challenge 2021 by the Biodiversity Team
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ai4er-cdt/gtc-biodiversity/main?urlpath=lab%2Ftree%2Fnotebooks)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+[![Documentation Status](https://readthedocs.org/projects/geograph/badge/?version=latest)](https://geograph.readthedocs.io/en/latest/?badge=latest)
 
  ![GeoGraphViewer demo gif](docs/images/viewer_demo.gif)
 


### PR DESCRIPTION
This PR adds our first interactive shield to the main readme (for whether the doc builds are passing). It also provides another link to the docs, which can't hurt.