### PR TITLE
Add automatic upload to pypi GitHub action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,42 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish package to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,7 @@ Polygon Data Visualisation
    installation
    tutorials
    geograph
+   maintenance
    about
 
 

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -1,0 +1,20 @@
+Maintenance
+===========
+
+Some tips for the maintainers of this project.
+
+Deploying
+---------
+
+A reminder for the maintainers on how to deploy. Follow this checklist (inspired by `this checklist <https://gist.github.com/audreyfeldroy/5990987>`_ and `this packaging tutorial <https://packaging.python.org/en/latest/tutorials/packaging-projects/>`_):
+
+1. Update ``HISTORY.rst`` and commit with message like "aux: add changelog for upcoming release 0.1.0"
+2. Run
+
+    .. code-block:: console
+
+        bump2version patch # possible: major / minor / patch
+
+3. Push commits *and tags* (`see here how to do this in vscode <https://stackoverflow.com/a/66086007>`_)
+4. Merge pull request into ``main`` branch.
+5. Add release on GitHub (using existing tag)


### PR DESCRIPTION
This adds a GitHub action that automatically builds and uploads the package once a new release tag is added on GitHub (via the web interface).